### PR TITLE
feat(db): adopt yoyo-migrations and reduce assets schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@ export BOGLE_DATABASE_URL="postgresql://user:password@host:5432/bogle"
 ```bash
 pip install -e .
 ```
+
+## Schema migrations
+
+Schema changes live in `src/bogle/migrations/` as numbered SQL files (`001_initial.sql`, `002_*.sql`, ...). They are applied by `yoyo-migrations`, which records progress in a `_yoyo_migration` table on the database side.
+
+Apply pending migrations programmatically:
+
+```python
+from bogle.db import run_migrations
+run_migrations()
+```
+
+To add a new migration, drop a new file in `src/bogle/migrations/` following the existing numbering and naming convention. yoyo will pick it up automatically on the next call to `run_migrations`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "typer>=0.9",
     "psycopg[binary]>=3.1",
+    "yoyo-migrations>=9.0",
 ]
 
 [project.optional-dependencies]

--- a/src/bogle/db.py
+++ b/src/bogle/db.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import psycopg
 from psycopg.rows import dict_row
-from yoyo import get_backend, read_migrations
+from yoyo import read_migrations
+from yoyo.backends.core.postgresql import PostgresqlPsycopgBackend
+from yoyo.connections import parse_uri
 
 DEFAULT_DATABASE_URL = "postgresql://localhost/bogle"
 DEFAULT_TIMEZONE = "America/Sao_Paulo"
@@ -47,16 +49,61 @@ def _yoyo_url(database_url: str) -> str:
     return database_url
 
 
+class _MigrationsSchemaBackend(PostgresqlPsycopgBackend):
+    """yoyo backend whose bookkeeping tables live in a dedicated
+    ``migrations`` schema, isolating them from the application tables in
+    ``public``."""
+
+    log_table = "migrations.yoyo_log"
+    version_table = "migrations.yoyo_version"
+    lock_table = "migrations.yoyo_lock"
+
+    def quote_identifier(self, s: str) -> str:
+        # PostgreSQL requires each part of a schema-qualified identifier
+        # to be quoted independently (`"schema"."table"`), not as a single
+        # identifier (`"schema.table"`) which the default implementation
+        # would produce.
+        if "." in s:
+            return ".".join(f'"{p}"' for p in s.split("."))
+        return f'"{s}"'
+
+    def list_tables(self, **kwargs) -> list[str]:
+        # Return schema-qualified names so the internal-schema bookkeeping
+        # logic in yoyo recognises tables we placed in the `migrations`
+        # schema. The default impl filters by ``current_schema`` only,
+        # which would always miss them.
+        cursor = self.execute(
+            "SELECT table_schema || '.' || table_name "
+            "FROM information_schema.tables "
+            "WHERE table_schema IN ('public', 'migrations')"
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+
 def run_migrations(database_url: str | None = None) -> None:
     """Apply any pending migrations from ``src/bogle/migrations/``.
 
-    Idempotent: yoyo records applied migrations in ``_yoyo_migration`` and
-    skips them on subsequent runs.
+    yoyo bookkeeping tables (``yoyo_migration``, ``yoyo_log``,
+    ``yoyo_version``, ``yoyo_lock``) are created in a dedicated
+    ``migrations`` schema. The schema is created on the fly if missing.
+
+    Idempotent: yoyo records applied migrations and skips them on
+    subsequent runs.
     """
     if database_url is None:
         database_url = get_database_url()
 
-    backend = get_backend(_yoyo_url(database_url))
+    with psycopg.connect(database_url) as setup_conn:
+        with setup_conn.cursor() as cur:
+            cur.execute("CREATE SCHEMA IF NOT EXISTS migrations")
+        setup_conn.commit()
+
+    parsed = parse_uri(_yoyo_url(database_url))
+    backend = _MigrationsSchemaBackend(
+        parsed,
+        "migrations.yoyo_migration",
+    )
+    backend.init_database()
     migrations = read_migrations(str(_migrations_path()))
     with backend.lock():
         backend.apply_migrations(backend.to_apply(migrations))

--- a/src/bogle/db.py
+++ b/src/bogle/db.py
@@ -1,42 +1,14 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import psycopg
 from psycopg.rows import dict_row
+from yoyo import get_backend, read_migrations
 
 DEFAULT_DATABASE_URL = "postgresql://localhost/bogle"
 DEFAULT_TIMEZONE = "America/Sao_Paulo"
-
-_SCHEMA_SQL = """
-CREATE TABLE IF NOT EXISTS assets (
-    ticker        TEXT PRIMARY KEY,
-    target_weight NUMERIC(5, 4) NOT NULL,
-    name          TEXT
-);
-
-CREATE TABLE IF NOT EXISTS transactions (
-    id               BIGSERIAL    PRIMARY KEY,
-    ticker           TEXT         NOT NULL REFERENCES assets(ticker),
-    purchase_date    TIMESTAMPTZ  NOT NULL,
-    shares           NUMERIC(20, 8) NOT NULL,
-    unit_price       NUMERIC(20, 4) NOT NULL,
-    total_investment NUMERIC(20, 4) NOT NULL,
-    fees             NUMERIC(20, 4) NOT NULL DEFAULT 0,
-    total_cost       NUMERIC(20, 4) NOT NULL
-);
-
-CREATE OR REPLACE VIEW holdings AS
-SELECT
-    t.ticker,
-    a.target_weight,
-    SUM(t.shares)                      AS total_shares,
-    SUM(t.total_cost)                  AS total_cost,
-    SUM(t.total_cost) / SUM(t.shares)  AS avg_cost_per_share
-FROM transactions t
-JOIN assets a ON t.ticker = a.ticker
-GROUP BY t.ticker, a.target_weight;
-"""
 
 
 def get_database_url() -> str:
@@ -64,8 +36,27 @@ def get_connection(database_url: str | None = None) -> psycopg.Connection:
     return conn
 
 
-def init_db(conn: psycopg.Connection) -> None:
-    """Create tables and views if they don't already exist (idempotent)."""
-    with conn.cursor() as cur:
-        cur.execute(_SCHEMA_SQL)
-    conn.commit()
+def _migrations_path() -> Path:
+    return Path(__file__).parent / "migrations"
+
+
+def _yoyo_url(database_url: str) -> str:
+    # yoyo-migrations needs the explicit psycopg3 driver scheme.
+    if database_url.startswith("postgresql://"):
+        return database_url.replace("postgresql://", "postgresql+psycopg://", 1)
+    return database_url
+
+
+def run_migrations(database_url: str | None = None) -> None:
+    """Apply any pending migrations from ``src/bogle/migrations/``.
+
+    Idempotent: yoyo records applied migrations in ``_yoyo_migration`` and
+    skips them on subsequent runs.
+    """
+    if database_url is None:
+        database_url = get_database_url()
+
+    backend = get_backend(_yoyo_url(database_url))
+    migrations = read_migrations(str(_migrations_path()))
+    with backend.lock():
+        backend.apply_migrations(backend.to_apply(migrations))

--- a/src/bogle/migrations/001_initial.sql
+++ b/src/bogle/migrations/001_initial.sql
@@ -1,0 +1,32 @@
+-- 001_initial: minimal portfolio schema.
+--
+-- assets       — user-defined target allocation per ticker.
+-- transactions — record of purchases (sales/dividends arrive in 003).
+-- holdings     — simple aggregation view (filter for active positions arrives in 004).
+
+CREATE TABLE assets (
+    ticker        TEXT PRIMARY KEY,
+    target_weight NUMERIC(5, 4) NOT NULL CHECK (target_weight > 0 AND target_weight <= 1)
+);
+
+CREATE TABLE transactions (
+    id               BIGSERIAL      PRIMARY KEY,
+    ticker           TEXT           NOT NULL REFERENCES assets(ticker),
+    purchase_date    TIMESTAMPTZ    NOT NULL,
+    shares           NUMERIC(20, 8) NOT NULL,
+    unit_price       NUMERIC(20, 4) NOT NULL,
+    total_investment NUMERIC(20, 4) NOT NULL,
+    fees             NUMERIC(20, 4) NOT NULL DEFAULT 0,
+    total_cost       NUMERIC(20, 4) NOT NULL
+);
+
+CREATE VIEW holdings AS
+SELECT
+    t.ticker,
+    a.target_weight,
+    SUM(t.shares)                      AS total_shares,
+    SUM(t.total_cost)                  AS total_cost,
+    SUM(t.total_cost) / SUM(t.shares)  AS avg_cost_per_share
+FROM transactions t
+JOIN assets a ON t.ticker = a.ticker
+GROUP BY t.ticker, a.target_weight;

--- a/src/bogle/models.py
+++ b/src/bogle/models.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
-
 import psycopg
-
-_UNSET = object()
 
 
 # ---------------------------------------------------------------------------
@@ -15,14 +11,13 @@ def add_asset(
     conn: psycopg.Connection,
     ticker: str,
     target_weight: float,
-    name: str | None = None,
 ) -> None:
     """Insert a new asset. Raises ``psycopg.errors.UniqueViolation`` if the
     ticker already exists."""
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO assets (ticker, target_weight, name) VALUES (%s, %s, %s)",
-            (ticker.upper(), target_weight, name),
+            "INSERT INTO assets (ticker, target_weight) VALUES (%s, %s)",
+            (ticker.upper(), target_weight),
         )
     conn.commit()
 
@@ -31,7 +26,7 @@ def get_asset(conn: psycopg.Connection, ticker: str) -> dict | None:
     """Return a single asset row, or ``None`` if not found."""
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT ticker, target_weight, name FROM assets WHERE ticker = %s",
+            "SELECT ticker, target_weight FROM assets WHERE ticker = %s",
             (ticker.upper(),),
         )
         return cur.fetchone()
@@ -41,7 +36,7 @@ def list_assets(conn: psycopg.Connection) -> list[dict]:
     """Return all assets ordered by ticker."""
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT ticker, target_weight, name FROM assets ORDER BY ticker"
+            "SELECT ticker, target_weight FROM assets ORDER BY ticker"
         )
         return cur.fetchall()
 
@@ -49,32 +44,16 @@ def list_assets(conn: psycopg.Connection) -> list[dict]:
 def update_asset(
     conn: psycopg.Connection,
     ticker: str,
-    target_weight: float | None = None,
-    name: str | None = _UNSET,  # type: ignore[assignment]
+    target_weight: float,
 ) -> bool:
-    """Update mutable fields of an existing asset.
+    """Update the target_weight of an existing asset.
 
-    Only the supplied keyword arguments are changed. Returns ``True`` if a row
-    was updated.
+    Returns ``True`` if a row was updated.
     """
-    fields: list[str] = []
-    values: list[Any] = []
-
-    if target_weight is not None:
-        fields.append("target_weight = %s")
-        values.append(target_weight)
-    if name is not _UNSET:
-        fields.append("name = %s")
-        values.append(name)
-
-    if not fields:
-        return False
-
-    values.append(ticker.upper())
     with conn.cursor() as cur:
         cur.execute(
-            f"UPDATE assets SET {', '.join(fields)} WHERE ticker = %s",  # noqa: S608
-            values,
+            "UPDATE assets SET target_weight = %s WHERE ticker = %s",
+            (target_weight, ticker.upper()),
         )
         rowcount = cur.rowcount
     conn.commit()


### PR DESCRIPTION
Closes #4.

## Summary

- Introduce `yoyo-migrations` as the schema management tool. Migration files live in `src/bogle/migrations/` (packaged with the source so they ship with installs).
- First migration `001_initial.sql` defines:
  - `assets` with **only** `ticker` (PK) and `target_weight` (`NUMERIC(5, 4)` with `CHECK (target_weight > 0 AND target_weight <= 1)`). The `name` column is gone.
  - `transactions` with the same shape from #3 (Postgres types).
  - `holdings` view (simple sum aggregation; will be filtered for active positions in a later migration tracked by #9).
- `db.run_migrations()` replaces `init_db()`. It is **idempotent** (yoyo records applied migrations in `_yoyo_migration` and skips them on subsequent runs).
- `models.py` aligned with the reduced `assets` schema: `add_asset`, `get_asset`, `list_assets`, `update_asset` no longer reference `name`.
- README documents the migration convention and how to add new ones.

## Scope

This PR covers Issue 0.2 (yoyo-migrations + initial schema) and the `name` column removal that was technically Issue 1.1 territory but is inseparable from defining migration 001. The remaining 1.1-1.5 sub-tasks (Typer commands) stay in #2.

## Test plan

- [x] `dropdb bogle && createdb bogle && python -c "from bogle.db import run_migrations; run_migrations()"` applies migration 001 cleanly.
- [x] Schema verified via `information_schema.columns`: `assets` has exactly `ticker` (text) and `target_weight` (numeric).
- [x] CRUD smoke test (insert/list/update/delete) against the migrated DB.
- [x] CHECK constraint rejects `target_weight = 1.5` with `CheckViolation`.
- [x] Running `run_migrations()` twice in a row is a no-op (idempotent).
- [x] yoyo tracking inspected: `_yoyo_migration` row for `001_initial`.
- [ ] Reviewer: drop and recreate the local `bogle` database, run `pip install -e .`, then call `run_migrations()`. Verify that schema matches expectations.

## Migration notes for the reviewer

Anyone with the schema from #3 (which had a `name` column) needs to drop and recreate the local DB:

```bash
dropdb bogle && createdb bogle
python -c "from bogle.db import run_migrations; run_migrations()"
```

Per the project decision, no auto-migration from the previous schema is implemented — the dataset is empty in practice.