### PR TITLE
build(deps): add rich as direct dependency for tabular CLI output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "typer>=0.9",
     "psycopg[binary]>=3.1",
     "yoyo-migrations>=9.0",
+    "rich>=13.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #5.

## Summary

Declare `rich >= 13.0` as a direct dependency in `pyproject.toml`. It already arrives transitively via `typer`, but pinning it as a direct dep makes the contract explicit: the upcoming `bogle list` (and later `position`, `summary`, `compare`, etc.) rely on `rich.table.Table` and friends.

## Test plan

- [x] `pip install -e .` succeeds.
- [x] Smoke test: `from rich.table import Table; Table(...).add_row(...)` renders correctly through `rich.console.Console`.