### PR TITLE
feat(assets): extend schema and repository to support multiple asset types

### DIFF
--- a/src/bogle/domain/assets.py
+++ b/src/bogle/domain/assets.py
@@ -1,10 +1,60 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
+from enum import StrEnum
+
+
+class AssetType(StrEnum):
+    """Categories of assets supported by bogle.
+
+    Variable-income instruments (STOCK, BDR, FII, ETF) carry only ticker
+    and target weight. Tesouro Direto and private fixed-income
+    instruments (CDB, RDB, LCI, LCA, CAIXINHA) carry additional metadata
+    (issuer, indexer, rate, ...) checked at the database level.
+    """
+
+    STOCK = "STOCK"
+    BDR = "BDR"
+    FII = "FII"
+    ETF = "ETF"
+    TESOURO = "TESOURO"
+    CDB = "CDB"
+    RDB = "RDB"
+    LCI = "LCI"
+    LCA = "LCA"
+    CAIXINHA = "CAIXINHA"
+
+
+class Indexer(StrEnum):
+    CDI = "CDI"
+    CDI_PLUS = "CDI+"
+    IPCA_PLUS = "IPCA+"
+    SELIC = "SELIC"
+    PREFIXADO = "PREFIXADO"
+
+
+# Convenience groups used by validation logic.
+VARIABLE_INCOME_TYPES = frozenset({
+    AssetType.STOCK, AssetType.BDR, AssetType.FII, AssetType.ETF,
+})
+PRIVATE_FIXED_INCOME_TYPES = frozenset({
+    AssetType.CDB, AssetType.RDB, AssetType.LCI, AssetType.LCA,
+    AssetType.CAIXINHA,
+})
+FIXED_INCOME_TYPES = PRIVATE_FIXED_INCOME_TYPES | {AssetType.TESOURO}
 
 
 @dataclass(frozen=True, slots=True)
 class Asset:
     ticker: str
     target_weight: Decimal
+    asset_type: AssetType = AssetType.STOCK
+    issuer: str | None = None
+    indexer: Indexer | None = None
+    rate: Decimal | None = None
+    is_prefixed: bool | None = None
+    daily_liquidity: bool | None = None
+    purchase_date: datetime | None = None
+    maturity_date: datetime | None = None

--- a/src/bogle/migrations/002_extend_assets_for_asset_types.sql
+++ b/src/bogle/migrations/002_extend_assets_for_asset_types.sql
@@ -1,0 +1,79 @@
+-- 002_extend_assets_for_asset_types: support multiple asset types.
+--
+-- Adds the metadata columns needed to describe BDR/FII/ETF, Tesouro Direto
+-- and private fixed-income instruments (CDB/RDB/LCI/LCA/CAIXINHA). The
+-- CHECK constraints below enforce coherence between fields so that an
+-- inconsistent row (e.g. a STOCK with a maturity date, a non-prefixed CDB
+-- without an indexer) cannot be persisted.
+
+ALTER TABLE assets
+    ADD COLUMN asset_type      TEXT NOT NULL,
+    ADD COLUMN issuer          TEXT,
+    ADD COLUMN indexer         TEXT,
+    ADD COLUMN rate            NUMERIC(10, 6),
+    ADD COLUMN is_prefixed     BOOLEAN,
+    ADD COLUMN daily_liquidity BOOLEAN,
+    ADD COLUMN purchase_date   TIMESTAMPTZ,
+    ADD COLUMN maturity_date   TIMESTAMPTZ;
+
+-- 1) asset_type must be one of the supported categories.
+ALTER TABLE assets
+    ADD CONSTRAINT assets_asset_type_valid CHECK (
+        asset_type IN (
+            'STOCK', 'BDR', 'FII', 'ETF',
+            'TESOURO',
+            'CDB', 'RDB', 'LCI', 'LCA', 'CAIXINHA'
+        )
+    );
+
+-- 2) indexer (when set) must be one of the supported tags.
+ALTER TABLE assets
+    ADD CONSTRAINT assets_indexer_valid CHECK (
+        indexer IS NULL
+        OR indexer IN ('CDI', 'CDI+', 'IPCA+', 'SELIC', 'PREFIXADO')
+    );
+
+-- 3) Variable-income instruments must not carry any fixed-income metadata.
+ALTER TABLE assets
+    ADD CONSTRAINT assets_variable_income_clean CHECK (
+        asset_type NOT IN ('STOCK', 'BDR', 'FII', 'ETF')
+        OR (
+            issuer IS NULL
+            AND indexer IS NULL
+            AND rate IS NULL
+            AND is_prefixed IS NULL
+            AND daily_liquidity IS NULL
+            AND purchase_date IS NULL
+            AND maturity_date IS NULL
+        )
+    );
+
+-- 4) Prefixed instruments do not have an indexer.
+ALTER TABLE assets
+    ADD CONSTRAINT assets_prefixed_no_indexer CHECK (
+        is_prefixed IS NULL OR is_prefixed = false OR indexer IS NULL
+    );
+
+-- 5) Instruments without daily liquidity must declare a maturity date.
+ALTER TABLE assets
+    ADD CONSTRAINT assets_no_liquidity_requires_maturity CHECK (
+        daily_liquidity IS NULL
+        OR daily_liquidity = true
+        OR maturity_date IS NOT NULL
+    );
+
+-- 6) Defensive: private fixed income (banco emissor) must declare the issuer.
+ALTER TABLE assets
+    ADD CONSTRAINT assets_private_fixed_income_requires_issuer CHECK (
+        asset_type NOT IN ('CDB', 'RDB', 'LCI', 'LCA', 'CAIXINHA')
+        OR issuer IS NOT NULL
+    );
+
+-- 7) Defensive: non-prefixed fixed income must declare an indexer.
+ALTER TABLE assets
+    ADD CONSTRAINT assets_postfixed_requires_indexer CHECK (
+        asset_type NOT IN ('TESOURO', 'CDB', 'RDB', 'LCI', 'LCA', 'CAIXINHA')
+        OR is_prefixed IS NULL
+        OR is_prefixed = true
+        OR indexer IS NOT NULL
+    );

--- a/src/bogle/repositories/assets.py
+++ b/src/bogle/repositories/assets.py
@@ -1,25 +1,48 @@
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
 
 import psycopg
 from psycopg import errors as pg_errors
 
-from bogle.domain.assets import Asset
+from bogle.domain.assets import Asset, AssetType, Indexer
 from bogle.domain.errors import (
     AssetAlreadyExistsError,
     AssetHasTransactionsError,
     AssetNotFoundError,
+    ValidationError,
     WeightSumExceededError,
 )
+
+
+_SELECT_COLUMNS = (
+    "ticker, target_weight, asset_type, issuer, indexer, rate, "
+    "is_prefixed, daily_liquidity, purchase_date, maturity_date"
+)
+
+
+def _row_to_asset(row: dict) -> Asset:
+    return Asset(
+        ticker=row["ticker"],
+        target_weight=row["target_weight"],
+        asset_type=AssetType(row["asset_type"]),
+        issuer=row["issuer"],
+        indexer=Indexer(row["indexer"]) if row["indexer"] is not None else None,
+        rate=row["rate"],
+        is_prefixed=row["is_prefixed"],
+        daily_liquidity=row["daily_liquidity"],
+        purchase_date=row["purchase_date"],
+        maturity_date=row["maturity_date"],
+    )
 
 
 class AssetRepository:
     """Data access for the ``assets`` table.
 
-    All methods enforce the invariant ``SUM(target_weight) <= 1`` atomically:
-    any operation that would break the invariant is rolled back and a
-    ``WeightSumExceededError`` is raised.
+    All write methods enforce the invariant ``SUM(target_weight) <= 1``
+    atomically: any operation that would break the invariant is rolled
+    back and a ``WeightSumExceededError`` is raised.
     """
 
     def __init__(self, conn: psycopg.Connection) -> None:
@@ -32,43 +55,81 @@ class AssetRepository:
     def get(self, ticker: str) -> Asset | None:
         with self._conn.cursor() as cur:
             cur.execute(
-                "SELECT ticker, target_weight FROM assets WHERE ticker = %s",
+                f"SELECT {_SELECT_COLUMNS} FROM assets WHERE ticker = %s",
                 (ticker.upper(),),
             )
             row = cur.fetchone()
-        if row is None:
-            return None
-        return Asset(ticker=row["ticker"], target_weight=row["target_weight"])
+        return _row_to_asset(row) if row is not None else None
 
     def list(self) -> list[Asset]:
         with self._conn.cursor() as cur:
             cur.execute(
-                "SELECT ticker, target_weight FROM assets ORDER BY ticker"
+                f"SELECT {_SELECT_COLUMNS} FROM assets ORDER BY ticker"
             )
             rows = cur.fetchall()
-        return [
-            Asset(ticker=r["ticker"], target_weight=r["target_weight"])
-            for r in rows
-        ]
+        return [_row_to_asset(r) for r in rows]
 
     # ------------------------------------------------------------------
     # Writes
     # ------------------------------------------------------------------
 
-    def add(self, ticker: str, target_weight: Decimal) -> Asset:
+    def add(
+        self,
+        ticker: str,
+        target_weight: Decimal,
+        *,
+        asset_type: AssetType = AssetType.STOCK,
+        issuer: str | None = None,
+        indexer: Indexer | None = None,
+        rate: Decimal | None = None,
+        is_prefixed: bool | None = None,
+        daily_liquidity: bool | None = None,
+        purchase_date: datetime | None = None,
+        maturity_date: datetime | None = None,
+    ) -> Asset:
         ticker = ticker.upper()
         try:
             with self._conn.transaction():
                 with self._conn.cursor() as cur:
                     cur.execute(
-                        "INSERT INTO assets (ticker, target_weight) "
-                        "VALUES (%s, %s)",
-                        (ticker, target_weight),
+                        """
+                        INSERT INTO assets (
+                            ticker, target_weight, asset_type, issuer,
+                            indexer, rate, is_prefixed, daily_liquidity,
+                            purchase_date, maturity_date
+                        ) VALUES (
+                            %s, %s, %s, %s,
+                            %s, %s, %s, %s,
+                            %s, %s
+                        )
+                        """,
+                        (
+                            ticker, target_weight, asset_type.value, issuer,
+                            indexer.value if indexer is not None else None,
+                            rate, is_prefixed, daily_liquidity,
+                            purchase_date, maturity_date,
+                        ),
                     )
                     self._guard_weight_sum(cur)
         except pg_errors.UniqueViolation:
             raise AssetAlreadyExistsError(ticker) from None
-        return Asset(ticker=ticker, target_weight=target_weight)
+        except pg_errors.CheckViolation as exc:
+            raise ValidationError(
+                f"Combinacao invalida de campos para o tipo {asset_type.value} "
+                f"(constraint {exc.diag.constraint_name})."
+            ) from None
+        return Asset(
+            ticker=ticker,
+            target_weight=target_weight,
+            asset_type=asset_type,
+            issuer=issuer,
+            indexer=indexer,
+            rate=rate,
+            is_prefixed=is_prefixed,
+            daily_liquidity=daily_liquidity,
+            purchase_date=purchase_date,
+            maturity_date=maturity_date,
+        )
 
     def update_weight(self, ticker: str, target_weight: Decimal) -> Asset:
         ticker = ticker.upper()
@@ -81,7 +142,10 @@ class AssetRepository:
                 if cur.rowcount == 0:
                     raise AssetNotFoundError(ticker)
                 self._guard_weight_sum(cur)
-        return Asset(ticker=ticker, target_weight=target_weight)
+        # Return the freshly updated row (need full state, not just weight).
+        result = self.get(ticker)
+        assert result is not None  # row existed (rowcount > 0).
+        return result
 
     def remove(self, ticker: str) -> None:
         ticker = ticker.upper()


### PR DESCRIPTION
Closes #6.

## Summary

Migration 002 extends `assets` with the metadata needed to describe Tesouro Direto and private fixed-income instruments alongside the existing variable-income tickers. Domain layer gains the matching enums and dataclass fields; repository round-trips them all.

The CLI does not change in this PR — it continues to accept only `--weight` and creates STOCK assets by default. Exposing the new flags belongs to #7.

## Schema (migration 002)

New columns on `assets`:

- `asset_type` (TEXT, **NOT NULL, no default**) — one of `STOCK`, `BDR`, `FII`, `ETF`, `TESOURO`, `CDB`, `RDB`, `LCI`, `LCA`, `CAIXINHA`.
- `issuer` (TEXT, NULL) — banco emissor.
- `indexer` (TEXT, NULL) — `CDI`, `CDI+`, `IPCA+`, `SELIC`, `PREFIXADO`.
- `rate` (NUMERIC(10, 6), NULL) — meaning depends on indexer.
- `is_prefixed` (BOOLEAN, NULL).
- `daily_liquidity` (BOOLEAN, NULL).
- `purchase_date` (TIMESTAMPTZ, NULL).
- `maturity_date` (TIMESTAMPTZ, NULL).

Decided NOT NULL without default per the discussion: a default of `'STOCK'` would silently miscategorise rows from any future code path (CSV import, demo seed) that forgets to specify the type. The CHECK constraint catches user typos either way; explicit-on-write is the bigger win.

## CHECK constraints (7)

1. `assets_asset_type_valid` — value belongs to the supported set.
2. `assets_indexer_valid` — when set, indexer belongs to the supported set.
3. `assets_variable_income_clean` — STOCK/BDR/FII/ETF must leave all fixed-income fields NULL.
4. `assets_prefixed_no_indexer` — `is_prefixed = true` -> `indexer IS NULL`.
5. `assets_no_liquidity_requires_maturity` — `daily_liquidity = false` -> `maturity_date IS NOT NULL`.
6. **(defensive)** `assets_private_fixed_income_requires_issuer` — CDB/RDB/LCI/LCA/CAIXINHA require `issuer IS NOT NULL`.
7. **(defensive)** `assets_postfixed_requires_indexer` — non-prefixed Tesouro/CDB/RDB/LCI/LCA/CAIXINHA require `indexer IS NOT NULL`.

## Domain layer

`bogle/domain/assets.py` now exports:

- `AssetType` (StrEnum, 10 values).
- `Indexer` (StrEnum, 5 values).
- Convenience groups: `VARIABLE_INCOME_TYPES`, `PRIVATE_FIXED_INCOME_TYPES`, `FIXED_INCOME_TYPES`.
- `Asset` dataclass extended with the eight new optional fields. Defaults match what STOCK/BDR/FII/ETF expect (everything `None`, `asset_type=AssetType.STOCK`).

## Repository

- `AssetRepository.add` gains keyword-only arguments for every new field; existing call sites (`repo.add(ticker, weight)`) keep working unchanged.
- Insert maps `psycopg.errors.CheckViolation` to `ValidationError` so the CLI shim renders `erro: Combinacao invalida de campos para o tipo X (constraint Y).` instead of a stack trace.
- `get` and `list` read all columns and reconstruct the full `Asset`.
- `update_weight` returns the freshly-read row (gives callers full state, not just the weight that was sent).

## Test plan

End-to-end against a real Postgres (`dropdb && createdb && run_migrations`):

- [x] Migration 002 applies cleanly on top of 001 (yoyo records both).
- [x] All 7 CHECK constraints listed by `pg_constraint` after migration.
- [x] Round-trip insert + read for STOCK (default), FII, TESOURO IPCA+, and CDB pos-fixado CDI — all reconstruct the dataclass correctly.
- [x] Negative tests confirm each CHECK rejects the corresponding violation:
  - STOCK with `issuer='X'` -> `assets_variable_income_clean`.
  - CDB prefixed with `indexer=CDI` -> `assets_prefixed_no_indexer`.
  - CDB without daily liquidity and no maturity -> `assets_no_liquidity_requires_maturity`.
  - Private RF without `issuer` -> `assets_private_fixed_income_requires_issuer`.
  - Post-fixed RF without `indexer` -> `assets_postfixed_requires_indexer`.
  - Raw SQL with bogus `asset_type` -> `assets_asset_type_valid`.
  - Raw SQL with bogus `indexer` -> `assets_indexer_valid`.
- [x] `CheckViolation` is translated to `ValidationError` with friendly message.
- [x] Existing CLI flow (`bogle add`/`update`/`remove`/`list`) still works against the new schema.