### PR TITLE
chore(gitignore): ignora pastas ocultas e arquivos MD exceto README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__/
 *.pyc
+.*/
+
+*.md
+!README.md


### PR DESCRIPTION
## Resumo
- Ignora todas as pastas ocultas (`.*/`), como `.venv`, `.claude`, `.pytest_cache` e `.ruff_cache`
- Ignora todos os arquivos Markdown (`*.md`), com exceção do `README.md` (`!README.md`)

## Observação
O padrão `.*/` também passa a ignorar pastas ocultas que eventualmente precisem ser versionadas no futuro (ex: `.github/`). Nesse caso, basta adicionar uma exceção `!.github/`.