### PR TITLE
feat(cli): valida parametros por asset_type no comando add

### DIFF
--- a/src/bogle/cli/assets.py
+++ b/src/bogle/cli/assets.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
+from zoneinfo import ZoneInfo
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from bogle.db import get_connection
+from bogle.db import DEFAULT_TIMEZONE, get_connection
+from bogle.domain.assets import AssetType, Indexer
 from bogle.domain.errors import ValidationError
+from bogle.domain.validation import validate_asset_metadata
 from bogle.repositories.assets import AssetRepository
 
 
@@ -26,6 +31,50 @@ def _parse_weight(value: str) -> Decimal:
     return weight
 
 
+def _parse_rate(value: str) -> Decimal:
+    try:
+        rate = Decimal(value)
+    except InvalidOperation:
+        raise ValidationError(f"--rate deve ser um numero decimal, recebido {value!r}.") from None
+    # Limite espelha a coluna rate NUMERIC(10, 6): |valor| < 10^4.
+    if not (Decimal("0") < rate < Decimal("10000")):
+        raise ValidationError(f"--rate deve estar em (0, 10000), recebido {rate}.")
+    return rate
+
+
+def _parse_date(value: str, option: str) -> datetime:
+    """Parse an ISO date (YYYY-MM-DD) into an America/Sao_Paulo datetime."""
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{option} deve ser uma data ISO (YYYY-MM-DD), recebido {value!r}.") from None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=ZoneInfo(DEFAULT_TIMEZONE))
+    return parsed
+
+
+def _parse_provided[T](
+    value: str | None,
+    parser: Callable[[str], T],
+    parse_errors: list[str],
+    placeholder: T,
+) -> T | None:
+    """Parse an optional CLI value, accumulating failures.
+
+    On parse failure the error is recorded and ``placeholder`` is returned
+    so the validator still sees the field as *provided* (and can report
+    missing/irrelevant fields in the same message). The placeholder is
+    never persisted: any accumulated error aborts before the database.
+    """
+    if value is None:
+        return None
+    try:
+        return parser(value)
+    except ValidationError as exc:
+        parse_errors.append(str(exc))
+        return placeholder
+
+
 def add(
     ticker: str = typer.Argument(..., help="Ticker do ativo (ex: VTI)."),
     weight: str = typer.Option(
@@ -34,14 +83,85 @@ def add(
         "-w",
         help="Peso-alvo em decimal entre 0 e 1 (ex: 0.6 = 60%).",
     ),
+    asset_type: AssetType = typer.Option(  # noqa: B008 — padrao do typer, OptionInfo e sentinela imutavel
+        AssetType.STOCK,
+        "--type",
+        "-t",
+        case_sensitive=False,
+        help="Tipo do ativo.",
+    ),
+    issuer: str | None = typer.Option(
+        None,
+        "--issuer",
+        help="Banco/emissor (renda fixa privada).",
+    ),
+    indexer: Indexer | None = typer.Option(  # noqa: B008 — padrao do typer, OptionInfo e sentinela imutavel
+        None,
+        "--indexer",
+        case_sensitive=False,
+        help="Indexador (renda fixa pos-fixada).",
+    ),
+    rate: str | None = typer.Option(
+        None,
+        "--rate",
+        help="Taxa contratada em decimal (ex: 1.10 = 110% do CDI).",
+    ),
+    prefixed: bool | None = typer.Option(
+        None,
+        "--prefixed/--no-prefixed",
+        help="Titulo prefixado (sem indexador). Default: pos-fixado.",
+    ),
+    daily_liquidity: bool | None = typer.Option(
+        None,
+        "--daily-liquidity/--no-daily-liquidity",
+        help="Liquidez diaria (renda fixa privada).",
+    ),
+    purchase_date: str | None = typer.Option(
+        None,
+        "--purchase-date",
+        help="Data da compra (YYYY-MM-DD).",
+    ),
+    maturity_date: str | None = typer.Option(
+        None,
+        "--maturity-date",
+        help="Data de vencimento (YYYY-MM-DD).",
+    ),
 ) -> None:
     weight_dec = _parse_weight(weight)
+    parse_errors: list[str] = []
+    placeholder_date = datetime(1970, 1, 1, tzinfo=UTC)
+    metadata = validate_asset_metadata(
+        asset_type,
+        issuer=issuer,
+        indexer=indexer,
+        rate=_parse_provided(rate, _parse_rate, parse_errors, Decimal("1")),
+        is_prefixed=prefixed,
+        daily_liquidity=daily_liquidity,
+        purchase_date=_parse_provided(
+            purchase_date, lambda v: _parse_date(v, "--purchase-date"), parse_errors, placeholder_date
+        ),
+        maturity_date=_parse_provided(
+            maturity_date, lambda v: _parse_date(v, "--maturity-date"), parse_errors, placeholder_date
+        ),
+        extra_errors=parse_errors,
+    )
     conn = get_connection()
     try:
-        asset = AssetRepository(conn).add(ticker, weight_dec)
+        asset = AssetRepository(conn).add(
+            ticker,
+            weight_dec,
+            asset_type=asset_type,
+            issuer=metadata.issuer,
+            indexer=metadata.indexer,
+            rate=metadata.rate,
+            is_prefixed=metadata.is_prefixed,
+            daily_liquidity=metadata.daily_liquidity,
+            purchase_date=metadata.purchase_date,
+            maturity_date=metadata.maturity_date,
+        )
     finally:
         conn.close()
-    typer.echo(f"asset {asset.ticker} adicionado com peso {asset.target_weight:.2%}.")
+    typer.echo(f"asset {asset.ticker} ({asset.asset_type}) adicionado com peso {asset.target_weight:.2%}.")
 
 
 def update(
@@ -53,6 +173,9 @@ def update(
         help="Novo peso-alvo em decimal entre 0 e 1.",
     ),
 ) -> None:
+    # `update` so toca target_weight por enquanto; quando passar a aceitar
+    # os campos de renda fixa, deve revalidar a combinacao resultante via
+    # bogle.domain.validation.validate_asset_metadata.
     if weight is None:
         raise ValidationError("Nada para atualizar. Informe --weight.")
     weight_dec = _parse_weight(weight)

--- a/src/bogle/domain/validation.py
+++ b/src/bogle/domain/validation.py
@@ -1,0 +1,141 @@
+"""Per-asset-type validation of asset metadata (issue 2.2).
+
+Valid field combinations per ``asset_type``::
+
+    | asset_type                   | issuer | indexer | rate | is_prefixed | daily_liquidity | purchase_date | maturity_date       |
+    |------------------------------|--------|---------|------|-------------|-----------------|---------------|---------------------|
+    | STOCK BDR FII ETF            | -      | -       | -    | -           | -               | -             | -                   |
+    | TESOURO                      | -      | req*    | req  | req         | -               | req           | req                 |
+    | CDB RDB LCI LCA CAIXINHA     | req    | req*    | req  | req         | req             | req           | if !daily_liquidity |
+
+    -     field must NOT be provided (irrelevant for the type).
+    req   field is required.
+    *     indexer is null only when ``is_prefixed = true`` (a prefixed
+          instrument has no indexer); required otherwise.
+
+For fixed income, ``is_prefixed`` defaults to ``false`` (pos-fixado) when
+omitted; prefixed instruments are declared with the ``--prefixed`` flag.
+``maturity_date`` is optional for private fixed income with daily
+liquidity (a CDB com liquidez diaria ainda pode ter vencimento).
+
+The database CHECK constraints in migration 002 enforce a *subset* of
+these rules as a last line of defense (e.g. they do not require rate or
+purchase_date); this module is the source of truth and exists so the CLI
+reports every problem at once, with friendly messages, before touching
+the database.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from bogle.domain.assets import (
+    PRIVATE_FIXED_INCOME_TYPES,
+    VARIABLE_INCOME_TYPES,
+    AssetType,
+    Indexer,
+)
+from bogle.domain.errors import ValidationError
+
+
+@dataclass(frozen=True, slots=True)
+class AssetMetadata:
+    """Normalized per-type metadata, ready for ``AssetRepository.add``."""
+
+    issuer: str | None = None
+    indexer: Indexer | None = None
+    rate: Decimal | None = None
+    is_prefixed: bool | None = None
+    daily_liquidity: bool | None = None
+    purchase_date: datetime | None = None
+    maturity_date: datetime | None = None
+
+
+def validate_asset_metadata(
+    asset_type: AssetType,
+    *,
+    issuer: str | None = None,
+    indexer: Indexer | None = None,
+    rate: Decimal | None = None,
+    is_prefixed: bool | None = None,
+    daily_liquidity: bool | None = None,
+    purchase_date: datetime | None = None,
+    maturity_date: datetime | None = None,
+    extra_errors: Sequence[str] = (),
+) -> AssetMetadata:
+    """Validate the field combination for ``asset_type``.
+
+    ``None`` means "not provided by the user". Collects *every* problem
+    (missing and irrelevant fields alike) and raises a single
+    ``ValidationError`` listing them all; on success returns the
+    normalized metadata (e.g. ``is_prefixed`` defaulted for fixed income).
+
+    ``extra_errors`` lets the caller fold upstream problems (e.g. CLI
+    parse failures) into the same aggregated report.
+    """
+    errors: list[str] = list(extra_errors)
+
+    if asset_type in VARIABLE_INCOME_TYPES:
+        provided = {
+            "--issuer": issuer,
+            "--indexer": indexer,
+            "--rate": rate,
+            "--prefixed/--no-prefixed": is_prefixed,
+            "--daily-liquidity/--no-daily-liquidity": daily_liquidity,
+            "--purchase-date": purchase_date,
+            "--maturity-date": maturity_date,
+        }
+        errors.extend(
+            f"{option} nao se aplica ao tipo {asset_type}." for option, value in provided.items() if value is not None
+        )
+        _raise_if_any(asset_type, errors)
+        return AssetMetadata()
+
+    # Fixed income (TESOURO + CDB/RDB/LCI/LCA/CAIXINHA).
+    prefixed = is_prefixed if is_prefixed is not None else False
+    if indexer is Indexer.PREFIXADO:
+        errors.append("para titulos prefixados use --prefixed em vez de --indexer PREFIXADO.")
+    elif prefixed and indexer is not None:
+        errors.append("--indexer nao deve ser informado junto com --prefixed (titulo prefixado nao tem indexador).")
+    elif not prefixed and indexer is None:
+        errors.append(f"--indexer e obrigatorio para {asset_type} pos-fixado (ou use --prefixed).")
+
+    if rate is None:
+        errors.append(f"--rate e obrigatorio para {asset_type}.")
+    if purchase_date is None:
+        errors.append(f"--purchase-date e obrigatorio para {asset_type}.")
+
+    if asset_type in PRIVATE_FIXED_INCOME_TYPES:
+        if issuer is None:
+            errors.append(f"--issuer e obrigatorio para {asset_type}.")
+        if daily_liquidity is None:
+            errors.append(f"--daily-liquidity/--no-daily-liquidity e obrigatorio para {asset_type}.")
+        elif daily_liquidity is False and maturity_date is None:
+            errors.append(f"--maturity-date e obrigatorio para {asset_type} sem liquidez diaria.")
+    else:  # TESOURO
+        if issuer is not None:
+            errors.append("--issuer nao se aplica ao tipo TESOURO.")
+        if daily_liquidity is not None:
+            errors.append("--daily-liquidity/--no-daily-liquidity nao se aplica ao tipo TESOURO.")
+        if maturity_date is None:
+            errors.append("--maturity-date e obrigatorio para TESOURO.")
+
+    _raise_if_any(asset_type, errors)
+    return AssetMetadata(
+        issuer=issuer,
+        indexer=None if prefixed else indexer,
+        rate=rate,
+        is_prefixed=prefixed,
+        daily_liquidity=daily_liquidity,
+        purchase_date=purchase_date,
+        maturity_date=maturity_date,
+    )
+
+
+def _raise_if_any(asset_type: AssetType, errors: list[str]) -> None:
+    if errors:
+        listing = "\n".join(f"  - {e}" for e in errors)
+        raise ValidationError(f"parametros invalidos para o tipo {asset_type}:\n{listing}")

--- a/tests/test_asset_validation.py
+++ b/tests/test_asset_validation.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from bogle.domain.assets import AssetType, Indexer
+from bogle.domain.errors import ValidationError
+from bogle.domain.validation import validate_asset_metadata
+
+PURCHASE = datetime(2026, 4, 1, tzinfo=UTC)
+MATURITY = datetime(2027, 4, 1, tzinfo=UTC)
+
+
+class TestVariableIncome:
+    @pytest.mark.parametrize("asset_type", [AssetType.STOCK, AssetType.BDR, AssetType.FII, AssetType.ETF])
+    def test_bare_is_valid(self, asset_type: AssetType) -> None:
+        metadata = validate_asset_metadata(asset_type)
+        assert metadata.issuer is None
+        assert metadata.indexer is None
+        assert metadata.is_prefixed is None
+
+    def test_single_irrelevant_field_raises(self) -> None:
+        with pytest.raises(ValidationError, match="--issuer nao se aplica ao tipo STOCK"):
+            validate_asset_metadata(AssetType.STOCK, issuer="Petrobras")
+
+    def test_all_irrelevant_fields_listed_at_once(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_asset_metadata(
+                AssetType.ETF,
+                issuer="X",
+                indexer=Indexer.CDI,
+                rate=Decimal("1.1"),
+                is_prefixed=False,
+                daily_liquidity=True,
+                purchase_date=PURCHASE,
+                maturity_date=MATURITY,
+            )
+        message = str(exc.value)
+        for option in (
+            "--issuer",
+            "--indexer",
+            "--rate",
+            "--prefixed/--no-prefixed",
+            "--daily-liquidity/--no-daily-liquidity",
+            "--purchase-date",
+            "--maturity-date",
+        ):
+            assert option in message
+
+
+class TestTesouro:
+    def test_postfixed_happy_path(self) -> None:
+        metadata = validate_asset_metadata(
+            AssetType.TESOURO,
+            indexer=Indexer.IPCA_PLUS,
+            rate=Decimal("0.065"),
+            purchase_date=PURCHASE,
+            maturity_date=MATURITY,
+        )
+        # is_prefixed normalizado para False (pos-fixado e o default).
+        assert metadata.is_prefixed is False
+        assert metadata.indexer is Indexer.IPCA_PLUS
+
+    def test_prefixed_happy_path(self) -> None:
+        metadata = validate_asset_metadata(
+            AssetType.TESOURO,
+            is_prefixed=True,
+            rate=Decimal("0.12"),
+            purchase_date=PURCHASE,
+            maturity_date=MATURITY,
+        )
+        assert metadata.is_prefixed is True
+        assert metadata.indexer is None
+
+    def test_all_missing_fields_listed_at_once(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_asset_metadata(AssetType.TESOURO)
+        message = str(exc.value)
+        for option in ("--indexer", "--rate", "--purchase-date", "--maturity-date"):
+            assert option in message
+
+    def test_issuer_is_irrelevant(self) -> None:
+        with pytest.raises(ValidationError, match="--issuer nao se aplica ao tipo TESOURO"):
+            validate_asset_metadata(
+                AssetType.TESOURO,
+                issuer="Tesouro Nacional",
+                indexer=Indexer.SELIC,
+                rate=Decimal("0.001"),
+                purchase_date=PURCHASE,
+                maturity_date=MATURITY,
+            )
+
+    @pytest.mark.parametrize("daily_liquidity", [True, False])
+    def test_daily_liquidity_is_irrelevant(self, daily_liquidity: bool) -> None:
+        with pytest.raises(ValidationError, match="nao se aplica ao tipo TESOURO"):
+            validate_asset_metadata(
+                AssetType.TESOURO,
+                indexer=Indexer.SELIC,
+                rate=Decimal("0.001"),
+                daily_liquidity=daily_liquidity,
+                purchase_date=PURCHASE,
+                maturity_date=MATURITY,
+            )
+
+    def test_prefixed_with_indexer_raises(self) -> None:
+        with pytest.raises(ValidationError, match="--indexer nao deve ser informado junto com --prefixed"):
+            validate_asset_metadata(
+                AssetType.TESOURO,
+                is_prefixed=True,
+                indexer=Indexer.IPCA_PLUS,
+                rate=Decimal("0.12"),
+                purchase_date=PURCHASE,
+                maturity_date=MATURITY,
+            )
+
+    def test_indexer_prefixado_suggests_flag(self) -> None:
+        with pytest.raises(ValidationError, match="use --prefixed em vez de --indexer PREFIXADO"):
+            validate_asset_metadata(
+                AssetType.TESOURO,
+                indexer=Indexer.PREFIXADO,
+                rate=Decimal("0.12"),
+                purchase_date=PURCHASE,
+                maturity_date=MATURITY,
+            )
+
+
+class TestPrivateFixedIncome:
+    def test_no_daily_liquidity_happy_path(self) -> None:
+        metadata = validate_asset_metadata(
+            AssetType.CDB,
+            issuer="XP Investimentos",
+            indexer=Indexer.CDI,
+            rate=Decimal("1.10"),
+            daily_liquidity=False,
+            purchase_date=PURCHASE,
+            maturity_date=MATURITY,
+        )
+        assert metadata.is_prefixed is False
+        assert metadata.daily_liquidity is False
+
+    def test_daily_liquidity_does_not_require_maturity(self) -> None:
+        metadata = validate_asset_metadata(
+            AssetType.CAIXINHA,
+            issuer="Nubank",
+            indexer=Indexer.CDI,
+            rate=Decimal("1.0"),
+            daily_liquidity=True,
+            purchase_date=PURCHASE,
+        )
+        assert metadata.maturity_date is None
+
+    def test_daily_liquidity_with_maturity_is_allowed(self) -> None:
+        metadata = validate_asset_metadata(
+            AssetType.LCI,
+            issuer="Banco Inter",
+            indexer=Indexer.CDI,
+            rate=Decimal("0.92"),
+            daily_liquidity=True,
+            purchase_date=PURCHASE,
+            maturity_date=MATURITY,
+        )
+        assert metadata.maturity_date == MATURITY
+
+    def test_all_missing_fields_listed_at_once(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_asset_metadata(AssetType.CDB)
+        message = str(exc.value)
+        for option in ("--issuer", "--indexer", "--rate", "--daily-liquidity", "--purchase-date"):
+            assert option in message
+
+    def test_no_daily_liquidity_without_maturity_raises(self) -> None:
+        with pytest.raises(ValidationError, match="--maturity-date e obrigatorio para RDB sem liquidez diaria"):
+            validate_asset_metadata(
+                AssetType.RDB,
+                issuer="Banco Z",
+                indexer=Indexer.CDI,
+                rate=Decimal("1.05"),
+                daily_liquidity=False,
+                purchase_date=PURCHASE,
+            )
+
+    def test_prefixed_happy_path(self) -> None:
+        metadata = validate_asset_metadata(
+            AssetType.LCA,
+            issuer="Banco do Brasil",
+            is_prefixed=True,
+            rate=Decimal("0.105"),
+            daily_liquidity=False,
+            purchase_date=PURCHASE,
+            maturity_date=MATURITY,
+        )
+        assert metadata.is_prefixed is True
+        assert metadata.indexer is None
+
+    def test_explicit_no_prefixed_requires_indexer(self) -> None:
+        with pytest.raises(ValidationError, match="--indexer e obrigatorio para CDB pos-fixado"):
+            validate_asset_metadata(
+                AssetType.CDB,
+                issuer="Banco W",
+                is_prefixed=False,
+                rate=Decimal("1.0"),
+                daily_liquidity=True,
+                purchase_date=PURCHASE,
+            )
+
+
+class TestExtraErrors:
+    def test_extra_errors_are_folded_into_the_report(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            validate_asset_metadata(
+                AssetType.CDB,
+                indexer=Indexer.CDI,
+                rate=Decimal("1.0"),
+                daily_liquidity=True,
+                purchase_date=PURCHASE,
+                extra_errors=["--rate deve ser um numero decimal, recebido 'abc'."],
+            )
+        message = str(exc.value)
+        assert "--rate deve ser um numero decimal" in message
+        assert "--issuer e obrigatorio para CDB" in message
+
+    def test_extra_errors_alone_still_raise(self) -> None:
+        with pytest.raises(ValidationError, match="boom"):
+            validate_asset_metadata(AssetType.STOCK, extra_errors=["boom"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 import os
 import subprocess
 from collections.abc import Iterator
+from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import psycopg
 import pytest
+from psycopg.rows import DictRow
+
+from bogle.domain.assets import AssetType, Indexer
+from bogle.repositories.assets import AssetRepository
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BOGLE_BIN = PROJECT_ROOT / ".venv" / "bin" / "bogle"
+SAO_PAULO = ZoneInfo("America/Sao_Paulo")
 
 
 @pytest.fixture(autouse=True)
@@ -82,3 +90,231 @@ def test_validation_weight_not_decimal() -> None:
     result = run_cli("add", "ABC", "-w", "foo")
     assert result.returncode == 1
     assert "deve ser um numero decimal" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Validacao por asset_type (issue 2.2)
+# ---------------------------------------------------------------------------
+
+
+def test_add_stock_with_explicit_type() -> None:
+    result = run_cli("add", "VTI", "--type", "STOCK", "--weight", "0.6")
+    assert result.returncode == 0
+    assert "VTI" in result.stdout
+    assert "60.00%" in result.stdout
+
+
+def test_add_cdb_full_metadata(conn: psycopg.Connection[DictRow]) -> None:
+    result = run_cli(
+        "add",
+        "CDB-XP-2027",
+        "--type",
+        "CDB",
+        "--weight",
+        "0.1",
+        "--issuer",
+        "XP Investimentos",
+        "--indexer",
+        "CDI",
+        "--rate",
+        "1.10",
+        "--purchase-date",
+        "2026-04-01",
+        "--maturity-date",
+        "2027-04-01",
+        "--no-daily-liquidity",
+    )
+    assert result.returncode == 0
+    assert "CDB-XP-2027" in result.stdout
+    assert "10.00%" in result.stdout
+
+    # Persistencia: garante que a fiacao CLI -> repository nao perde/troca campos.
+    asset = AssetRepository(conn).get("CDB-XP-2027")
+    assert asset is not None
+    assert asset.asset_type == AssetType.CDB
+    assert asset.issuer == "XP Investimentos"
+    assert asset.indexer == Indexer.CDI
+    assert asset.rate == Decimal("1.10")
+    assert asset.is_prefixed is False
+    assert asset.daily_liquidity is False
+    assert asset.purchase_date == datetime(2026, 4, 1, tzinfo=SAO_PAULO)
+    assert asset.maturity_date == datetime(2027, 4, 1, tzinfo=SAO_PAULO)
+
+
+def test_add_tesouro_prefixado(conn: psycopg.Connection[DictRow]) -> None:
+    result = run_cli(
+        "add",
+        "TESOURO-PRE-2029",
+        "--type",
+        "TESOURO",
+        "--weight",
+        "0.2",
+        "--prefixed",
+        "--rate",
+        "0.12",
+        "--purchase-date",
+        "2026-01-10",
+        "--maturity-date",
+        "2029-01-01",
+    )
+    assert result.returncode == 0
+    assert "TESOURO-PRE-2029" in result.stdout
+
+    asset = AssetRepository(conn).get("TESOURO-PRE-2029")
+    assert asset is not None
+    assert asset.asset_type == AssetType.TESOURO
+    assert asset.is_prefixed is True
+    assert asset.indexer is None
+    assert asset.issuer is None
+    assert asset.daily_liquidity is None
+    assert asset.purchase_date == datetime(2026, 1, 10, tzinfo=SAO_PAULO)
+
+
+def test_add_caixinha_daily_liquidity_without_maturity(conn: psycopg.Connection[DictRow]) -> None:
+    result = run_cli(
+        "add",
+        "CAIXINHA-NU",
+        "--type",
+        "CAIXINHA",
+        "--weight",
+        "0.05",
+        "--issuer",
+        "Nubank",
+        "--indexer",
+        "CDI",
+        "--rate",
+        "1.0",
+        "--purchase-date",
+        "2026-02-01",
+        "--daily-liquidity",
+    )
+    assert result.returncode == 0
+
+    asset = AssetRepository(conn).get("CAIXINHA-NU")
+    assert asset is not None
+    assert asset.daily_liquidity is True
+    assert asset.maturity_date is None
+    assert asset.is_prefixed is False
+
+
+def test_add_explicit_no_prefixed_requires_indexer() -> None:
+    result = run_cli(
+        "add",
+        "CDB-NP",
+        "--type",
+        "CDB",
+        "--weight",
+        "0.05",
+        "--no-prefixed",
+        "--issuer",
+        "Banco W",
+        "--rate",
+        "1.0",
+        "--purchase-date",
+        "2026-02-01",
+        "--daily-liquidity",
+    )
+    assert result.returncode == 1
+    assert "--indexer e obrigatorio para CDB pos-fixado" in result.stderr
+
+
+def test_add_type_and_indexer_are_case_insensitive() -> None:
+    result = run_cli(
+        "add",
+        "TES-IPCA-2035",
+        "--type",
+        "tesouro",
+        "--indexer",
+        "ipca+",
+        "--weight",
+        "0.1",
+        "--rate",
+        "0.065",
+        "--purchase-date",
+        "2026-01-10",
+        "--maturity-date",
+        "2035-05-15",
+    )
+    assert result.returncode == 0
+    assert "TES-IPCA-2035" in result.stdout
+
+
+def test_add_missing_fields_listed_all_at_once() -> None:
+    result = run_cli("add", "CDB-X", "--type", "CDB", "--weight", "0.1")
+    assert result.returncode == 1
+    for option in ("--issuer", "--indexer", "--rate", "--daily-liquidity", "--purchase-date"):
+        assert option in result.stderr
+
+
+def test_add_irrelevant_field_for_type_raises() -> None:
+    result = run_cli("add", "VTI", "--weight", "0.1", "--issuer", "Vanguard")
+    assert result.returncode == 1
+    assert "--issuer nao se aplica ao tipo STOCK" in result.stderr
+
+
+def test_add_invalid_date_format() -> None:
+    result = run_cli(
+        "add",
+        "CDB-Y",
+        "--type",
+        "CDB",
+        "--weight",
+        "0.1",
+        "--issuer",
+        "Banco Y",
+        "--indexer",
+        "CDI",
+        "--rate",
+        "1.0",
+        "--purchase-date",
+        "01/04/2026",
+        "--daily-liquidity",
+    )
+    assert result.returncode == 1
+    assert "--purchase-date deve ser uma data ISO" in result.stderr
+
+
+def test_add_parse_error_does_not_hide_missing_fields() -> None:
+    # --rate malformado + --issuer faltando: ambos na mesma mensagem.
+    result = run_cli(
+        "add",
+        "CDB-AGG",
+        "--type",
+        "CDB",
+        "--weight",
+        "0.05",
+        "--rate",
+        "abc",
+        "--indexer",
+        "CDI",
+        "--purchase-date",
+        "2026-01-01",
+        "--daily-liquidity",
+    )
+    assert result.returncode == 1
+    assert "--rate deve ser um numero decimal" in result.stderr
+    assert "--issuer e obrigatorio para CDB" in result.stderr
+
+
+def test_add_rate_overflow_is_friendly() -> None:
+    # Sem o limite do parser, NUMERIC(10, 6) estouraria com traceback cru.
+    result = run_cli(
+        "add",
+        "CDB-BIG",
+        "--type",
+        "CDB",
+        "--weight",
+        "0.05",
+        "--issuer",
+        "Banco B",
+        "--indexer",
+        "CDI",
+        "--rate",
+        "100000",
+        "--purchase-date",
+        "2026-01-01",
+        "--daily-liquidity",
+    )
+    assert result.returncode == 1
+    assert "--rate deve estar em (0, 10000)" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -1,0 +1,54 @@
+"""Unit tests for the CLI option parsers (in-process, no subprocess)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from bogle.cli.assets import _parse_date, _parse_rate, _parse_weight
+from bogle.domain.errors import ValidationError
+
+
+class TestParseDate:
+    def test_naive_date_gets_sao_paulo_timezone(self) -> None:
+        parsed = _parse_date("2026-04-01", "--purchase-date")
+        # Wall time preservado (meia-noite local), nao convertido.
+        assert parsed == datetime(2026, 4, 1, tzinfo=ZoneInfo("America/Sao_Paulo"))
+        assert parsed.hour == 0
+        assert parsed.tzinfo == ZoneInfo("America/Sao_Paulo")
+
+    def test_aware_input_keeps_its_timezone(self) -> None:
+        parsed = _parse_date("2026-04-01T12:00:00+00:00", "--purchase-date")
+        assert parsed == datetime(2026, 4, 1, 12, tzinfo=UTC)
+
+    def test_invalid_format_mentions_the_option(self) -> None:
+        with pytest.raises(ValidationError, match="--maturity-date deve ser uma data ISO"):
+            _parse_date("01/04/2026", "--maturity-date")
+
+
+class TestParseRate:
+    def test_valid_decimal(self) -> None:
+        assert _parse_rate("1.10") == Decimal("1.10")
+
+    def test_not_a_number(self) -> None:
+        with pytest.raises(ValidationError, match="--rate deve ser um numero decimal"):
+            _parse_rate("abc")
+
+    @pytest.mark.parametrize("value", ["0", "-5", "10000", "100000"])
+    def test_out_of_range(self, value: str) -> None:
+        # Limite superior espelha NUMERIC(10, 6): sem ele o psycopg
+        # estouraria com NumericValueOutOfRange cru.
+        with pytest.raises(ValidationError, match=r"--rate deve estar em \(0, 10000\)"):
+            _parse_rate(value)
+
+
+class TestParseWeight:
+    def test_valid(self) -> None:
+        assert _parse_weight("0.6") == Decimal("0.6")
+
+    def test_out_of_range(self) -> None:
+        with pytest.raises(ValidationError, match=r"deve estar em \(0, 1\]"):
+            _parse_weight("1.5")


### PR DESCRIPTION
## Contexto

Resolve #7 (2.2 — Validate parameters per asset_type in CLI). Com `assets` aceitando 10 tipos (issue 2.1), o `bogle add` passa a expor os campos de renda fixa e validar a combinacao por tipo antes de tocar o banco.

## O que muda

- **`domain/validation.py` (novo):** `validate_asset_metadata()` valida a combinacao de campos por `asset_type`, coletando **todos** os problemas (faltantes, irrelevantes e erros de parse via `extra_errors`) numa unica `ValidationError`. Tabela de combinacoes documentada no docstring do modulo. Normaliza `is_prefixed` (default `false` = pos-fixado em renda fixa).
- **`cli/assets.py`:** novas opcoes no `add`: `--type`, `--issuer`, `--indexer`, `--rate`, `--prefixed/--no-prefixed`, `--daily-liquidity/--no-daily-liquidity`, `--purchase-date`, `--maturity-date`. Datas naive recebem timezone America/Sao_Paulo; `--rate` limitado a (0, 10000) espelhando `NUMERIC(10, 6)` (sem isso o psycopg estourava com `NumericValueOutOfRange` cru).

## Decisoes de design

- `is_prefixed` omitido em renda fixa assume pos-fixado (o exemplo de aceite da issue passa `--indexer CDI` sem flag e precisa funcionar); titulo prefixado usa `--prefixed`, que proibe `--indexer` (espelha a constraint `assets_prefixed_no_indexer`).
- `--indexer PREFIXADO` e rejeitado com dica de usar `--prefixed`.
- TESOURO proibe `--issuer` e `--daily-liquidity` (celulas "-" na tabela da issue); `--maturity-date` e opcional em renda fixa privada com liquidez diaria.
- `update` segue aceitando apenas `--weight` — a issue cobre o update apenas "quando tocar campos relevantes", e ele ainda nao toca (comentario no codigo aponta a revalidacao futura).

## Criterios de aceite

- [x] `bogle add VTI --type STOCK --weight 0.6` funciona (so weight + ticker)
- [x] `bogle add CDB-XP-2027 --type CDB --weight 0.1 --issuer "XP Investimentos" --indexer CDI --rate 1.10 --purchase-date 2026-04-01 --maturity-date 2027-04-01 --no-daily-liquidity` funciona
- [x] Erros listam **todos** os campos faltantes de uma vez
- [x] Campos irrelevantes para o tipo geram erro
- [x] Documentacao das combinacoes em comentario no codigo

## Testes

Suite passa de 43 para 88 testes: validacao pura por tipo (`test_asset_validation.py`), parsers da CLI incluindo contrato de timezone (`test_cli_parsing.py`) e criterios de aceite fim-a-fim com assercao dos campos persistidos, tri-state das flags booleanas e case-insensitivity de `--type`/`--indexer` (`test_cli.py`). ruff e pyright limpos.