### PR TITLE
docs(readme): adiciona secao de uso com exemplos por tipo de ativo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,79 @@ export BOGLE_DATABASE_URL="postgresql://user:password@host:5432/bogle"
 pip install -e .
 ```
 
+## Usage
+
+Apply the schema migrations once before first use (see
+[Schema migrations](#schema-migrations) below).
+
+### Adding assets
+
+Every asset needs a ticker and a target weight in decimal (`0.4` = 40%).
+The sum of all target weights can never exceed `1.0` — `bogle` rejects
+any `add`/`update` that would break that.
+
+Variable income (`STOCK`, `BDR`, `FII`, `ETF`) takes nothing else:
+
+```bash
+bogle add VTI --weight 0.4              # --type STOCK is the default
+bogle add MXRF11 --type FII --weight 0.1
+```
+
+Tesouro Direto (`TESOURO`) requires indexer, rate and both dates:
+
+```bash
+bogle add TESOURO-IPCA-2035 --type TESOURO --weight 0.2 \
+  --indexer IPCA+ --rate 0.065 \
+  --purchase-date 2026-01-10 --maturity-date 2035-05-15
+```
+
+Private fixed income (`CDB`, `RDB`, `LCI`, `LCA`, `CAIXINHA`) also
+requires the issuer and a daily-liquidity flag; the maturity date is
+mandatory only without daily liquidity:
+
+```bash
+bogle add CDB-XP-2027 --type CDB --weight 0.1 \
+  --issuer "XP Investimentos" --indexer CDI --rate 1.10 \
+  --purchase-date 2026-04-01 --maturity-date 2027-04-01 \
+  --no-daily-liquidity
+
+bogle add CAIXINHA-NU --type CAIXINHA --weight 0.05 \
+  --issuer Nubank --indexer CDI --rate 1.0 \
+  --purchase-date 2026-02-01 --daily-liquidity
+```
+
+Prefixed instruments (fixed rate) use `--prefixed` instead of `--indexer`:
+
+```bash
+bogle add TESOURO-PRE-2029 --type TESOURO --weight 0.1 \
+  --prefixed --rate 0.12 \
+  --purchase-date 2026-01-10 --maturity-date 2029-01-01
+```
+
+### Fields per asset type
+
+| asset type                   | issuer   | indexer   | rate     | daily liquidity | purchase date | maturity date            |
+|------------------------------|----------|-----------|----------|-----------------|---------------|--------------------------|
+| STOCK, BDR, FII, ETF         | —        | —         | —        | —               | —             | —                        |
+| TESOURO                      | —        | required* | required | —               | required      | required                 |
+| CDB, RDB, LCI, LCA, CAIXINHA | required | required* | required | required        | required      | if no daily liquidity    |
+
+— means the field does not apply to the type; passing it is an error.
+\* post-fixed instruments (the default) require `--indexer`; prefixed
+ones use `--prefixed` and take no indexer.
+
+Validation reports every missing or misplaced field at once. Dates are
+ISO (`YYYY-MM-DD`), interpreted in America/Sao_Paulo. Rates are decimals
+(`1.10` = 110% of CDI, `0.065` = IPCA + 6.5%).
+
+### Managing the portfolio
+
+```bash
+bogle list                       # table of assets + the weight sum
+bogle update VTI --weight 0.45   # change a target weight
+bogle remove VTI                 # only works while the asset has no transactions
+```
+
 ## Schema migrations
 
 Schema changes live in `src/bogle/migrations/` as numbered SQL files (`001_initial.sql`, `002_*.sql`, ...). They are applied by `yoyo-migrations`, which records progress in a `_yoyo_migration` table on the database side.


### PR DESCRIPTION
## Contexto

O README cobria apenas setup e migracoes — nenhum comando da CLI estava documentado. Com a issue #7 mergeada, `bogle add` passou a aceitar 10 tipos de ativo com campos obrigatorios/proibidos diferentes por tipo, e um usuario novo nao tinha como descobrir isso sem tentativa e erro.

## O que muda

Nova secao **Usage** entre o setup e as migracoes:

- **Adding assets** — exemplos executaveis por categoria: renda variavel (so ticker + weight, `STOCK` e o default), Tesouro Direto (indexador/taxa/datas), renda fixa privada (emissor + flag de liquidez, cobrindo `--no-daily-liquidity` com vencimento e `--daily-liquidity` sem) e titulos prefixados (`--prefixed` no lugar de `--indexer`).
- **Fields per asset type** — tabela de combinacoes validas por tipo (mesma logica documentada em `domain/validation.py`), com a regra do indexador em nota e os formatos de data (ISO, America/Sao_Paulo), taxa e peso.
- **Managing the portfolio** — `list`, `update` e `remove` (com a restricao de transacoes vinculadas).
- Regra da soma de pesos <= 1.0 e lembrete de aplicar migracoes antes do primeiro uso.

A issue #8 (transactions) ficou intencionalmente de fora: e camada de biblioteca, sem comando na CLI ainda — sera documentada quando o epico da CLI de transacoes chegar.

## Validacao

Todos os exemplos foram executados em sequencia contra um banco limpo (os 6 `add`s, `list`, `update`, `remove`). Os pesos dos exemplos foram calibrados para copy-paste integral sem violar o limite de 1.0: os adds somam 95% e o `update` do exemplo fecha em exatamente 100%.