### PR TITLE
feat(cli): registro manual de transacoes (buy, sell, income)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,36 @@ bogle update VTI --weight 0.45   # change a target weight
 bogle remove VTI                 # only works while the asset has no transactions
 ```
 
+### Recording transactions
+
+Transactions reference a registered asset. `--date` is optional
+everywhere and defaults to today (America/Sao_Paulo); pass ISO dates
+(`YYYY-MM-DD`) to backfill history.
+
+```bash
+bogle add PETR4 --weight 0.2
+
+bogle buy PETR4 --shares 100 --price 30.50 --fees 5.20 --date 2026-01-15
+bogle sell PETR4 --shares 40 --price 35 --tax-withheld 0.07    # 0.005% "dedo-duro" on sales
+
+bogle income PETR4 --type DIVIDEND --amount 123.45
+bogle income PETR4 --type JCP --amount 200 --tax-withheld 30   # JCP requires the 15% withheld at source
+bogle income MXRF11 --type RENDIMENTO --amount 80              # FII income, tax-exempt (no --tax-withheld)
+
+bogle transactions          # list everything (or filter: bogle transactions PETR4)
+bogle transaction remove 7  # delete by ID (see the ID column in the listing)
+```
+
+**Fixed income without daily liquidity** (CDB, RDB, LCI, LCA): record
+the application as a single unit — BUY with `--shares 1` and `--price`
+equal to the invested amount. A full redemption is a SELL with
+`--shares 1` at the redeemed amount, which closes the position:
+
+```bash
+bogle buy CDB-XP-2027 --shares 1 --price 5000 --date 2026-04-01
+bogle sell CDB-XP-2027 --shares 1 --price 5310 --date 2027-04-01   # resgate total
+```
+
 ## Schema migrations
 
 Schema changes live in `src/bogle/migrations/` as numbered SQL files (`001_initial.sql`, `002_*.sql`, ...). They are applied by `yoyo-migrations`, which records progress in a `_yoyo_migration` table on the database side.

--- a/src/bogle/cli/__init__.py
+++ b/src/bogle/cli/__init__.py
@@ -5,6 +5,7 @@ import sys
 import typer
 
 from bogle.cli import assets as assets_cli
+from bogle.cli import transactions as transactions_cli
 from bogle.domain.errors import BogleError
 
 app = typer.Typer(
@@ -16,6 +17,15 @@ app.command("add", help="Adicionar um novo ativo a carteira.")(assets_cli.add)
 app.command("update", help="Atualizar o peso-alvo de um ativo.")(assets_cli.update)
 app.command("remove", help="Remover um ativo da carteira.")(assets_cli.remove)
 app.command("list", help="Listar todos os ativos cadastrados.")(assets_cli.list_assets)
+
+app.command("buy", help="Registrar uma compra.")(transactions_cli.buy)
+app.command("sell", help="Registrar uma venda (parcial ou total).")(transactions_cli.sell)
+app.command("income", help="Registrar um provento (dividendo, JCP, rendimento, juros).")(transactions_cli.income)
+app.command("transactions", help="Listar transacoes registradas.")(transactions_cli.list_transactions)
+
+transaction_app = typer.Typer(help="Operacoes sobre uma transacao individual.", no_args_is_help=True)
+transaction_app.command("remove", help="Remover uma transacao pelo ID.")(transactions_cli.remove)
+app.add_typer(transaction_app, name="transaction")
 
 
 @app.callback()

--- a/src/bogle/cli/__init__.py
+++ b/src/bogle/cli/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 
+import psycopg
 import typer
 
 from bogle.cli import assets as assets_cli
@@ -38,4 +39,11 @@ def _run() -> None:  # pragma: no cover - tiny shim for the console_script
         app()
     except BogleError as exc:
         typer.echo(f"erro: {exc}", err=True)
+        sys.exit(1)
+    except psycopg.OperationalError:
+        typer.echo(
+            "erro: nao foi possivel conectar ao banco de dados. "
+            "Verifique BOGLE_DATABASE_URL e se o PostgreSQL esta rodando.",
+            err=True,
+        )
         sys.exit(1)

--- a/src/bogle/cli/assets.py
+++ b/src/bogle/cli/assets.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import UTC, datetime
-from decimal import Decimal, InvalidOperation
-from zoneinfo import ZoneInfo
+from decimal import Decimal
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from bogle.db import DEFAULT_TIMEZONE, get_connection
+from bogle.cli.parsing import parse_date, parse_decimal
+from bogle.db import get_connection
 from bogle.domain.assets import AssetType, Indexer
 from bogle.domain.errors import ValidationError
 from bogle.domain.validation import validate_asset_metadata
@@ -17,40 +17,19 @@ from bogle.repositories.assets import AssetRepository
 
 
 def _parse_weight(value: str) -> Decimal:
-    """Parse a CLI weight argument, validating the (0, 1] range.
-
-    The argument arrives as a string so we get exact decimal handling
-    instead of going through ``float`` (and its 0.1 + 0.2 surprises).
-    """
-    try:
-        weight = Decimal(value)
-    except InvalidOperation:
-        raise ValidationError(f"--weight deve ser um numero decimal, recebido {value!r}.") from None
+    """Parse a CLI weight argument, validating the (0, 1] range."""
+    weight = parse_decimal(value, "--weight")
     if not (Decimal("0") < weight <= Decimal("1")):
         raise ValidationError(f"--weight deve estar em (0, 1], recebido {weight}.")
     return weight
 
 
 def _parse_rate(value: str) -> Decimal:
-    try:
-        rate = Decimal(value)
-    except InvalidOperation:
-        raise ValidationError(f"--rate deve ser um numero decimal, recebido {value!r}.") from None
+    rate = parse_decimal(value, "--rate")
     # Limite espelha a coluna rate NUMERIC(10, 6): |valor| < 10^4.
     if not (Decimal("0") < rate < Decimal("10000")):
         raise ValidationError(f"--rate deve estar em (0, 10000), recebido {rate}.")
     return rate
-
-
-def _parse_date(value: str, option: str) -> datetime:
-    """Parse an ISO date (YYYY-MM-DD) into an America/Sao_Paulo datetime."""
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError:
-        raise ValidationError(f"{option} deve ser uma data ISO (YYYY-MM-DD), recebido {value!r}.") from None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=ZoneInfo(DEFAULT_TIMEZONE))
-    return parsed
 
 
 def _parse_provided[T](
@@ -138,10 +117,10 @@ def add(
         is_prefixed=prefixed,
         daily_liquidity=daily_liquidity,
         purchase_date=_parse_provided(
-            purchase_date, lambda v: _parse_date(v, "--purchase-date"), parse_errors, placeholder_date
+            purchase_date, lambda v: parse_date(v, "--purchase-date"), parse_errors, placeholder_date
         ),
         maturity_date=_parse_provided(
-            maturity_date, lambda v: _parse_date(v, "--maturity-date"), parse_errors, placeholder_date
+            maturity_date, lambda v: parse_date(v, "--maturity-date"), parse_errors, placeholder_date
         ),
         extra_errors=parse_errors,
     )

--- a/src/bogle/cli/parsing.py
+++ b/src/bogle/cli/parsing.py
@@ -1,0 +1,42 @@
+"""Shared parsers for CLI options.
+
+Format-only validation lives here; range/coherence rules belong to the
+domain validators and repositories, which already aggregate friendly
+errors.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from zoneinfo import ZoneInfo
+
+from bogle.db import DEFAULT_TIMEZONE
+from bogle.domain.errors import ValidationError
+
+
+def parse_decimal(value: str, option: str) -> Decimal:
+    """Parse a CLI decimal argument.
+
+    The argument arrives as a string so we get exact decimal handling
+    instead of going through ``float`` (and its 0.1 + 0.2 surprises).
+    """
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation:
+        raise ValidationError(f"{option} deve ser um numero decimal, recebido {value!r}.") from None
+    # NaN/Infinity parseiam como Decimal mas estouram em comparacoes e no banco.
+    if not parsed.is_finite():
+        raise ValidationError(f"{option} deve ser um numero decimal, recebido {value!r}.")
+    return parsed
+
+
+def parse_date(value: str, option: str) -> datetime:
+    """Parse an ISO date (YYYY-MM-DD) into an America/Sao_Paulo datetime."""
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        raise ValidationError(f"{option} deve ser uma data ISO (YYYY-MM-DD), recebido {value!r}.") from None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=ZoneInfo(DEFAULT_TIMEZONE))
+    return parsed

--- a/src/bogle/cli/transactions.py
+++ b/src/bogle/cli/transactions.py
@@ -29,14 +29,14 @@ class IncomeType(StrEnum):
 
 
 def _resolve_date(value: str | None) -> datetime:
-    """``--date`` informado (ISO) ou agora em America/Sao_Paulo."""
+    """Return the given ISO ``--date`` or now in America/Sao_Paulo."""
     if value is not None:
         return parse_date(value, "--date")
     return datetime.now(tz=ZoneInfo(DEFAULT_TIMEZONE))
 
 
 def _fmt(value: Decimal) -> str:
-    """Exibe sem a escala crua do NUMERIC (100.00000000 -> 100)."""
+    """Render without the raw NUMERIC scale (100.00000000 -> 100)."""
     return format(value.normalize(), "f")
 
 
@@ -51,15 +51,14 @@ def buy(
     fees: str = typer.Option("0", "--fees", help="Taxas/corretagem da operacao."),
     date: str | None = typer.Option(None, "--date", help="Data da operacao (YYYY-MM-DD). Default: hoje."),
 ) -> None:
+    # Parse antes de abrir conexao (erro de formato nao precisa de banco).
+    when = _resolve_date(date)
+    shares_dec = parse_decimal(shares, "--shares")
+    price_dec = parse_decimal(price, "--price")
+    fees_dec = parse_decimal(fees, "--fees")
     conn = get_connection()
     try:
-        tx = TransactionRepository(conn).add_buy(
-            ticker,
-            _resolve_date(date),
-            shares=parse_decimal(shares, "--shares"),
-            unit_price=parse_decimal(price, "--price"),
-            fees=parse_decimal(fees, "--fees"),
-        )
+        tx = TransactionRepository(conn).add_buy(ticker, when, shares=shares_dec, unit_price=price_dec, fees=fees_dec)
     finally:
         conn.close()
     _echo_recorded(tx)
@@ -76,15 +75,16 @@ def sell(
     tax_withheld: str = typer.Option("0", "--tax-withheld", help="IR retido na fonte (dedo-duro de 0,005% em vendas)."),
     date: str | None = typer.Option(None, "--date", help="Data da operacao (YYYY-MM-DD). Default: hoje."),
 ) -> None:
+    # Parse antes de abrir conexao (erro de formato nao precisa de banco).
+    when = _resolve_date(date)
+    shares_dec = parse_decimal(shares, "--shares")
+    price_dec = parse_decimal(price, "--price")
+    fees_dec = parse_decimal(fees, "--fees")
+    tax_dec = parse_decimal(tax_withheld, "--tax-withheld")
     conn = get_connection()
     try:
         tx = TransactionRepository(conn).add_sale(
-            ticker,
-            _resolve_date(date),
-            shares=parse_decimal(shares, "--shares"),
-            unit_price=parse_decimal(price, "--price"),
-            fees=parse_decimal(fees, "--fees"),
-            tax_withheld=parse_decimal(tax_withheld, "--tax-withheld"),
+            ticker, when, shares=shares_dec, unit_price=price_dec, fees=fees_dec, tax_withheld=tax_dec
         )
     finally:
         conn.close()
@@ -154,13 +154,13 @@ def list_transactions(
     table = Table(title="Transacoes", title_style="bold")
     table.add_column("ID", justify="right")
     table.add_column("Data", no_wrap=True)
-    table.add_column("Tipo")
+    table.add_column("Tipo", no_wrap=True)
     table.add_column("Ticker", style="cyan", no_wrap=True)
     table.add_column("Qtd", justify="right")
     table.add_column("Preco", justify="right")
     table.add_column("Valor", justify="right")
     table.add_column("Fees", justify="right")
-    table.add_column("IR retido", justify="right")
+    table.add_column("IR", justify="right")
     for tx in transactions:
         is_trade = tx.transaction_type in (TransactionType.BUY, TransactionType.SELL)
         table.add_row(

--- a/src/bogle/cli/transactions.py
+++ b/src/bogle/cli/transactions.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+from zoneinfo import ZoneInfo
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from bogle.cli.parsing import parse_date, parse_decimal
+from bogle.db import DEFAULT_TIMEZONE, get_connection
+from bogle.domain.errors import ValidationError
+from bogle.domain.transactions import Transaction, TransactionType
+from bogle.repositories.transactions import TransactionRepository
+
+
+class IncomeType(StrEnum):
+    """Income subset of ``TransactionType``, for the ``--type`` choices.
+
+    Kept separate so ``bogle income --help`` does not offer BUY/SELL.
+    """
+
+    DIVIDEND = "DIVIDEND"
+    JCP = "JCP"
+    RENDIMENTO = "RENDIMENTO"
+    INTEREST = "INTEREST"
+
+
+def _resolve_date(value: str | None) -> datetime:
+    """``--date`` informado (ISO) ou agora em America/Sao_Paulo."""
+    if value is not None:
+        return parse_date(value, "--date")
+    return datetime.now(tz=ZoneInfo(DEFAULT_TIMEZONE))
+
+
+def _fmt(value: Decimal) -> str:
+    """Exibe sem a escala crua do NUMERIC (100.00000000 -> 100)."""
+    return format(value.normalize(), "f")
+
+
+def _echo_recorded(tx: Transaction) -> None:
+    typer.echo(f"transacao {tx.id} registrada: {tx.transaction_type} {tx.ticker} em {tx.date:%Y-%m-%d}.")
+
+
+def buy(
+    ticker: str = typer.Argument(..., help="Ticker do ativo (precisa estar cadastrado)."),
+    shares: str = typer.Option(..., "--shares", "-s", help="Quantidade comprada."),
+    price: str = typer.Option(..., "--price", "-p", help="Preco unitario pago."),
+    fees: str = typer.Option("0", "--fees", help="Taxas/corretagem da operacao."),
+    date: str | None = typer.Option(None, "--date", help="Data da operacao (YYYY-MM-DD). Default: hoje."),
+) -> None:
+    conn = get_connection()
+    try:
+        tx = TransactionRepository(conn).add_buy(
+            ticker,
+            _resolve_date(date),
+            shares=parse_decimal(shares, "--shares"),
+            unit_price=parse_decimal(price, "--price"),
+            fees=parse_decimal(fees, "--fees"),
+        )
+    finally:
+        conn.close()
+    _echo_recorded(tx)
+    typer.echo(
+        f"custo total: {_fmt(tx.total_cost)} ({_fmt(tx.shares)} x {_fmt(tx.unit_price)} + {_fmt(tx.fees)} de fees)."
+    )
+
+
+def sell(
+    ticker: str = typer.Argument(..., help="Ticker do ativo."),
+    shares: str = typer.Option(..., "--shares", "-s", help="Quantidade vendida."),
+    price: str = typer.Option(..., "--price", "-p", help="Preco unitario de venda."),
+    fees: str = typer.Option("0", "--fees", help="Taxas/corretagem da operacao."),
+    tax_withheld: str = typer.Option("0", "--tax-withheld", help="IR retido na fonte (dedo-duro de 0,005% em vendas)."),
+    date: str | None = typer.Option(None, "--date", help="Data da operacao (YYYY-MM-DD). Default: hoje."),
+) -> None:
+    conn = get_connection()
+    try:
+        tx = TransactionRepository(conn).add_sale(
+            ticker,
+            _resolve_date(date),
+            shares=parse_decimal(shares, "--shares"),
+            unit_price=parse_decimal(price, "--price"),
+            fees=parse_decimal(fees, "--fees"),
+            tax_withheld=parse_decimal(tax_withheld, "--tax-withheld"),
+        )
+    finally:
+        conn.close()
+    _echo_recorded(tx)
+    typer.echo(f"produto bruto da venda: {_fmt(tx.total_investment)}; custo da operacao: {_fmt(tx.total_cost)}.")
+
+
+def income(
+    ticker: str = typer.Argument(..., help="Ticker do ativo."),
+    income_type: IncomeType = typer.Option(  # noqa: B008 — padrao do typer, OptionInfo e sentinela imutavel
+        ...,
+        "--type",
+        "-t",
+        case_sensitive=False,
+        help="Tipo do provento.",
+    ),
+    amount: str = typer.Option(..., "--amount", "-a", help="Valor bruto recebido."),
+    tax_withheld: str | None = typer.Option(
+        None,
+        "--tax-withheld",
+        help="IR retido na fonte. Obrigatorio para JCP; nao se aplica a RENDIMENTO.",
+    ),
+    date: str | None = typer.Option(None, "--date", help="Data do recebimento (YYYY-MM-DD). Default: hoje."),
+) -> None:
+    # JCP sempre tem 15% retido na fonte; RENDIMENTO de FII e isento para PF.
+    if income_type is IncomeType.JCP and tax_withheld is None:
+        raise ValidationError("--tax-withheld e obrigatorio para JCP (IR de 15% retido na fonte).")
+    if income_type is IncomeType.RENDIMENTO and tax_withheld is not None:
+        raise ValidationError("--tax-withheld nao se aplica a RENDIMENTO (isento para PF).")
+
+    amount_dec = parse_decimal(amount, "--amount")
+    tax_dec = parse_decimal(tax_withheld, "--tax-withheld") if tax_withheld is not None else None
+    when = _resolve_date(date)
+
+    conn = get_connection()
+    try:
+        repo = TransactionRepository(conn)
+        if income_type is IncomeType.DIVIDEND:
+            tx = repo.add_dividend(ticker, when, amount_dec, tax_withheld=tax_dec or Decimal("0"))
+        elif income_type is IncomeType.JCP:
+            assert tax_dec is not None  # garantido pela validacao acima
+            tx = repo.add_jcp(ticker, when, amount_dec, tax_dec)
+        elif income_type is IncomeType.RENDIMENTO:
+            tx = repo.add_rendimento(ticker, when, amount_dec)
+        else:
+            tx = repo.add_interest(ticker, when, amount_dec, tax_withheld=tax_dec or Decimal("0"))
+    finally:
+        conn.close()
+    _echo_recorded(tx)
+    typer.echo(f"valor bruto: {_fmt(tx.total_investment)}; IR retido: {_fmt(tx.tax_withheld)}.")
+
+
+def list_transactions(
+    ticker: str | None = typer.Argument(None, help="Filtra por ticker (opcional)."),
+) -> None:
+    conn = get_connection()
+    try:
+        transactions = TransactionRepository(conn).list(ticker)
+    finally:
+        conn.close()
+
+    if not transactions:
+        suffix = f" para {ticker.upper()}" if ticker else ""
+        typer.echo(f"Nenhuma transacao registrada{suffix}.")
+        return
+
+    table = Table(title="Transacoes", title_style="bold")
+    table.add_column("ID", justify="right")
+    table.add_column("Data", no_wrap=True)
+    table.add_column("Tipo")
+    table.add_column("Ticker", style="cyan", no_wrap=True)
+    table.add_column("Qtd", justify="right")
+    table.add_column("Preco", justify="right")
+    table.add_column("Valor", justify="right")
+    table.add_column("Fees", justify="right")
+    table.add_column("IR retido", justify="right")
+    for tx in transactions:
+        is_trade = tx.transaction_type in (TransactionType.BUY, TransactionType.SELL)
+        table.add_row(
+            str(tx.id),
+            f"{tx.date:%Y-%m-%d}",
+            tx.transaction_type,
+            tx.ticker,
+            _fmt(tx.shares) if is_trade else "-",
+            _fmt(tx.unit_price) if is_trade else "-",
+            _fmt(tx.total_investment),
+            _fmt(tx.fees),
+            _fmt(tx.tax_withheld),
+        )
+    Console().print(table)
+
+
+def remove(
+    transaction_id: int = typer.Argument(..., help="ID da transacao (veja 'bogle transactions')."),
+) -> None:
+    conn = get_connection()
+    try:
+        TransactionRepository(conn).delete(transaction_id)
+    finally:
+        conn.close()
+    typer.echo(f"transacao {transaction_id} removida.")

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -8,25 +8,26 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from bogle.cli.assets import _parse_date, _parse_rate, _parse_weight
+from bogle.cli.assets import _parse_rate, _parse_weight
+from bogle.cli.parsing import parse_date
 from bogle.domain.errors import ValidationError
 
 
 class TestParseDate:
     def test_naive_date_gets_sao_paulo_timezone(self) -> None:
-        parsed = _parse_date("2026-04-01", "--purchase-date")
+        parsed = parse_date("2026-04-01", "--purchase-date")
         # Wall time preservado (meia-noite local), nao convertido.
         assert parsed == datetime(2026, 4, 1, tzinfo=ZoneInfo("America/Sao_Paulo"))
         assert parsed.hour == 0
         assert parsed.tzinfo == ZoneInfo("America/Sao_Paulo")
 
     def test_aware_input_keeps_its_timezone(self) -> None:
-        parsed = _parse_date("2026-04-01T12:00:00+00:00", "--purchase-date")
+        parsed = parse_date("2026-04-01T12:00:00+00:00", "--purchase-date")
         assert parsed == datetime(2026, 4, 1, 12, tzinfo=UTC)
 
     def test_invalid_format_mentions_the_option(self) -> None:
         with pytest.raises(ValidationError, match="--maturity-date deve ser uma data ISO"):
-            _parse_date("01/04/2026", "--maturity-date")
+            parse_date("01/04/2026", "--maturity-date")
 
 
 class TestParseRate:

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -9,8 +9,19 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from bogle.cli.assets import _parse_rate, _parse_weight
-from bogle.cli.parsing import parse_date
+from bogle.cli.parsing import parse_date, parse_decimal
 from bogle.domain.errors import ValidationError
+
+
+class TestParseDecimal:
+    def test_valid(self) -> None:
+        assert parse_decimal("10.5", "--shares") == Decimal("10.5")
+
+    @pytest.mark.parametrize("value", ["NaN", "Infinity", "-Infinity", "inf"])
+    def test_non_finite_rejected(self, value: str) -> None:
+        # NaN/Infinity parseiam como Decimal mas estouram em comparacoes e no banco.
+        with pytest.raises(ValidationError, match="--shares deve ser um numero decimal"):
+            parse_decimal(value, "--shares")
 
 
 class TestParseDate:

--- a/tests/test_cli_transactions.py
+++ b/tests/test_cli_transactions.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import psycopg
+import pytest
+from psycopg.rows import DictRow
+
+from bogle.domain.transactions import TransactionType
+from bogle.repositories.assets import AssetRepository
+from bogle.repositories.transactions import TransactionRepository
+from tests.test_cli import SAO_PAULO, run_cli
+
+
+@pytest.fixture
+def petr4(repo: AssetRepository) -> None:
+    repo.add("PETR4", Decimal("0.2"))
+
+
+class TestBuy:
+    def test_success_and_persistence(
+        self, conn: psycopg.Connection[DictRow], trepo: TransactionRepository, petr4: None
+    ) -> None:
+        result = run_cli(
+            "buy", "PETR4", "--shares", "100", "--price", "30.50", "--fees", "5.20", "--date", "2026-01-15"
+        )
+        assert result.returncode == 0
+        assert "registrada: BUY PETR4 em 2026-01-15" in result.stdout
+        assert "custo total: 3055.2" in result.stdout
+
+        tx = trepo.list("PETR4")[0]
+        assert tx.transaction_type is TransactionType.BUY
+        assert tx.shares == Decimal("100")
+        assert tx.unit_price == Decimal("30.50")
+        assert tx.fees == Decimal("5.20")
+        assert tx.total_cost == Decimal("3055.20")
+        assert tx.date == datetime(2026, 1, 15, tzinfo=SAO_PAULO)
+
+    def test_date_defaults_to_today_in_sao_paulo(self, trepo: TransactionRepository, petr4: None) -> None:
+        assert run_cli("buy", "PETR4", "-s", "10", "-p", "5").returncode == 0
+        tx = trepo.list("PETR4")[0]
+        today_sp = datetime.now(tz=ZoneInfo("America/Sao_Paulo")).date()
+        assert tx.date.astimezone(ZoneInfo("America/Sao_Paulo")).date() == today_sp
+
+    def test_unknown_ticker_is_friendly(self) -> None:
+        result = run_cli("buy", "NOPE", "-s", "10", "-p", "5")
+        assert result.returncode == 1
+        assert "nao encontrado" in result.stderr
+        assert "Traceback" not in result.stderr
+
+    def test_repository_validation_surfaces_friendly(self, petr4: None) -> None:
+        result = run_cli("buy", "PETR4", "-s", "0", "-p", "-2")
+        assert result.returncode == 1
+        assert "shares deve ser maior que zero" in result.stderr
+        assert "unit_price deve ser maior que zero" in result.stderr
+
+    def test_invalid_decimal_is_friendly(self, petr4: None) -> None:
+        result = run_cli("buy", "PETR4", "-s", "abc", "-p", "5")
+        assert result.returncode == 1
+        assert "--shares deve ser um numero decimal" in result.stderr
+
+    def test_invalid_date_is_friendly(self, petr4: None) -> None:
+        result = run_cli("buy", "PETR4", "-s", "1", "-p", "5", "--date", "15/01/2026")
+        assert result.returncode == 1
+        assert "--date deve ser uma data ISO" in result.stderr
+
+
+class TestSell:
+    def test_success_with_tax_withheld(self, trepo: TransactionRepository, petr4: None) -> None:
+        assert run_cli("buy", "PETR4", "-s", "100", "-p", "30").returncode == 0
+        result = run_cli(
+            "sell",
+            "PETR4",
+            "-s",
+            "40",
+            "-p",
+            "35",
+            "--fees",
+            "2.50",
+            "--tax-withheld",
+            "0.07",
+            "--date",
+            "2026-03-10",
+        )
+        assert result.returncode == 0
+        assert "registrada: SELL PETR4" in result.stdout
+        assert "produto bruto da venda: 1400" in result.stdout
+
+        tx = next(t for t in trepo.list("PETR4") if t.transaction_type is TransactionType.SELL)
+        assert tx.shares == Decimal("40")
+        assert tx.total_investment == Decimal("1400")
+        assert tx.total_cost == Decimal("2.50")
+        assert tx.tax_withheld == Decimal("0.07")
+
+
+class TestIncome:
+    def test_dividend(self, trepo: TransactionRepository, petr4: None) -> None:
+        result = run_cli("income", "PETR4", "--type", "DIVIDEND", "--amount", "123.45")
+        assert result.returncode == 0
+        assert "registrada: DIVIDEND PETR4" in result.stdout
+        tx = trepo.list("PETR4")[0]
+        assert tx.transaction_type is TransactionType.DIVIDEND
+        assert tx.total_investment == Decimal("123.45")
+        assert tx.tax_withheld == Decimal("0")
+
+    def test_type_is_case_insensitive(self, petr4: None) -> None:
+        assert run_cli("income", "PETR4", "--type", "dividend", "--amount", "10").returncode == 0
+
+    def test_jcp_requires_tax_withheld(self, trepo: TransactionRepository, petr4: None) -> None:
+        result = run_cli("income", "PETR4", "--type", "JCP", "--amount", "200")
+        assert result.returncode == 1
+        assert "--tax-withheld e obrigatorio para JCP" in result.stderr
+
+        result = run_cli("income", "PETR4", "--type", "JCP", "--amount", "200", "--tax-withheld", "30")
+        assert result.returncode == 0
+        tx = trepo.list("PETR4")[0]
+        assert tx.transaction_type is TransactionType.JCP
+        assert tx.tax_withheld == Decimal("30")
+
+    def test_rendimento_rejects_tax_withheld(self, trepo: TransactionRepository, repo: AssetRepository) -> None:
+        repo.add("MXRF11", Decimal("0.05"))
+        result = run_cli("income", "MXRF11", "--type", "RENDIMENTO", "--amount", "80", "--tax-withheld", "1")
+        assert result.returncode == 1
+        assert "--tax-withheld nao se aplica a RENDIMENTO" in result.stderr
+
+        assert run_cli("income", "MXRF11", "--type", "RENDIMENTO", "--amount", "80").returncode == 0
+        tx = trepo.list("MXRF11")[0]
+        assert tx.transaction_type is TransactionType.RENDIMENTO
+        assert tx.tax_withheld == Decimal("0")
+
+    def test_interest(self, trepo: TransactionRepository, petr4: None) -> None:
+        result = run_cli("income", "PETR4", "--type", "INTEREST", "--amount", "55", "--tax-withheld", "12.375")
+        assert result.returncode == 0
+        tx = trepo.list("PETR4")[0]
+        assert tx.transaction_type is TransactionType.INTEREST
+        assert tx.tax_withheld == Decimal("12.375")
+
+    def test_buy_is_not_an_income_type(self, petr4: None) -> None:
+        result = run_cli("income", "PETR4", "--type", "BUY", "--amount", "10")
+        assert result.returncode == 2  # typer rejeita a choice antes do comando
+        assert "BUY" in result.stderr
+
+
+class TestListTransactions:
+    def test_empty(self) -> None:
+        result = run_cli("transactions")
+        assert result.returncode == 0
+        assert "Nenhuma transacao registrada." in result.stdout
+
+    def test_empty_with_ticker_filter(self) -> None:
+        result = run_cli("transactions", "petr4")
+        assert result.returncode == 0
+        assert "Nenhuma transacao registrada para PETR4." in result.stdout
+
+    def test_lists_recorded_transactions(self, petr4: None) -> None:
+        assert run_cli("buy", "PETR4", "-s", "100", "-p", "30", "--date", "2026-01-15").returncode == 0
+        assert run_cli("income", "PETR4", "--type", "DIVIDEND", "--amount", "9.9").returncode == 0
+        result = run_cli("transactions")
+        assert result.returncode == 0
+        assert "PETR4" in result.stdout
+        assert "BUY" in result.stdout
+        assert "DIVID" in result.stdout  # rich pode truncar a coluna
+        assert "2026-01-15" in result.stdout
+
+    def test_filter_by_ticker(self, petr4: None, repo: AssetRepository) -> None:
+        repo.add("VALE3", Decimal("0.1"))
+        assert run_cli("buy", "PETR4", "-s", "10", "-p", "30").returncode == 0
+        assert run_cli("buy", "VALE3", "-s", "5", "-p", "60").returncode == 0
+        result = run_cli("transactions", "VALE3")
+        assert "VALE3" in result.stdout
+        assert "PETR4" not in result.stdout
+
+
+class TestRemove:
+    def test_success(self, trepo: TransactionRepository, petr4: None) -> None:
+        assert run_cli("buy", "PETR4", "-s", "10", "-p", "30").returncode == 0
+        tx_id = trepo.list("PETR4")[0].id
+        result = run_cli("transaction", "remove", str(tx_id))
+        assert result.returncode == 0
+        assert f"transacao {tx_id} removida" in result.stdout
+        assert trepo.list("PETR4") == []
+
+    def test_missing_is_friendly(self) -> None:
+        result = run_cli("transaction", "remove", "999999")
+        assert result.returncode == 1
+        assert "Transacao 999999 nao encontrada" in result.stderr

--- a/tests/test_cli_transactions.py
+++ b/tests/test_cli_transactions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
@@ -8,15 +9,36 @@ import psycopg
 import pytest
 from psycopg.rows import DictRow
 
+from bogle.cli.transactions import _resolve_date
 from bogle.domain.transactions import TransactionType
 from bogle.repositories.assets import AssetRepository
 from bogle.repositories.transactions import TransactionRepository
 from tests.test_cli import SAO_PAULO, run_cli
 
 
+@pytest.fixture(autouse=True)
+def _truncate_for_cli(conn: psycopg.Connection) -> Iterator[None]:
+    """Forca o truncate da fixture ``conn`` em TODO teste deste modulo.
+
+    Sem isso, testes que nao pedem conn (ex.: listagem vazia) rodariam
+    contra residuos do teste anterior — fixtures autouse de modulo nao
+    atravessam arquivos.
+    """
+    yield
+
+
 @pytest.fixture
 def petr4(repo: AssetRepository) -> None:
     repo.add("PETR4", Decimal("0.2"))
+
+
+class TestResolveDate:
+    def test_default_is_timezone_aware_sao_paulo(self) -> None:
+        resolved = _resolve_date(None)
+        assert resolved.tzinfo == ZoneInfo("America/Sao_Paulo")
+
+    def test_explicit_date_is_parsed(self) -> None:
+        assert _resolve_date("2026-01-15") == datetime(2026, 1, 15, tzinfo=SAO_PAULO)
 
 
 class TestBuy:
@@ -28,7 +50,8 @@ class TestBuy:
         )
         assert result.returncode == 0
         assert "registrada: BUY PETR4 em 2026-01-15" in result.stdout
-        assert "custo total: 3055.2" in result.stdout
+        # Linha completa: pina tambem a normalizacao dos Decimais (_fmt).
+        assert "custo total: 3055.2 (100 x 30.5 + 5.2 de fees)." in result.stdout
 
         tx = trepo.list("PETR4")[0]
         assert tx.transaction_type is TransactionType.BUY
@@ -108,6 +131,12 @@ class TestIncome:
     def test_type_is_case_insensitive(self, petr4: None) -> None:
         assert run_cli("income", "PETR4", "--type", "dividend", "--amount", "10").returncode == 0
 
+    def test_dividend_with_explicit_tax_withheld(self, trepo: TransactionRepository, petr4: None) -> None:
+        result = run_cli("income", "PETR4", "--type", "DIVIDEND", "--amount", "100", "--tax-withheld", "1.5")
+        assert result.returncode == 0
+        tx = trepo.list("PETR4")[0]
+        assert tx.tax_withheld == Decimal("1.5")  # nao descartado no despacho
+
     def test_jcp_requires_tax_withheld(self, trepo: TransactionRepository, petr4: None) -> None:
         result = run_cli("income", "PETR4", "--type", "JCP", "--amount", "200")
         assert result.returncode == 1
@@ -117,6 +146,7 @@ class TestIncome:
         assert result.returncode == 0
         tx = trepo.list("PETR4")[0]
         assert tx.transaction_type is TransactionType.JCP
+        assert tx.total_investment == Decimal("200")
         assert tx.tax_withheld == Decimal("30")
 
     def test_rendimento_rejects_tax_withheld(self, trepo: TransactionRepository, repo: AssetRepository) -> None:
@@ -128,6 +158,7 @@ class TestIncome:
         assert run_cli("income", "MXRF11", "--type", "RENDIMENTO", "--amount", "80").returncode == 0
         tx = trepo.list("MXRF11")[0]
         assert tx.transaction_type is TransactionType.RENDIMENTO
+        assert tx.total_investment == Decimal("80")
         assert tx.tax_withheld == Decimal("0")
 
     def test_interest(self, trepo: TransactionRepository, petr4: None) -> None:
@@ -135,6 +166,7 @@ class TestIncome:
         assert result.returncode == 0
         tx = trepo.list("PETR4")[0]
         assert tx.transaction_type is TransactionType.INTEREST
+        assert tx.total_investment == Decimal("55")
         assert tx.tax_withheld == Decimal("12.375")
 
     def test_buy_is_not_an_income_type(self, petr4: None) -> None:
@@ -161,8 +193,9 @@ class TestListTransactions:
         assert result.returncode == 0
         assert "PETR4" in result.stdout
         assert "BUY" in result.stdout
-        assert "DIVID" in result.stdout  # rich pode truncar a coluna
+        assert "DIVIDEND" in result.stdout  # coluna Tipo com no_wrap, nao trunca
         assert "2026-01-15" in result.stdout
+        assert " - " in result.stdout  # placeholder de Qtd/Preco em linha de provento
 
     def test_filter_by_ticker(self, petr4: None, repo: AssetRepository) -> None:
         repo.add("VALE3", Decimal("0.1"))
@@ -186,3 +219,25 @@ class TestRemove:
         result = run_cli("transaction", "remove", "999999")
         assert result.returncode == 1
         assert "Transacao 999999 nao encontrada" in result.stderr
+
+
+class TestDatabaseUnreachable:
+    def test_friendly_error_without_traceback(self) -> None:
+        import os
+        import subprocess
+
+        from tests.test_cli import BOGLE_BIN, PROJECT_ROOT
+
+        env = os.environ.copy()
+        env["BOGLE_DATABASE_URL"] = "postgresql://localhost/bogle_db_que_nao_existe"
+        result = subprocess.run(
+            [str(BOGLE_BIN), "transactions"],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(PROJECT_ROOT),
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "nao foi possivel conectar ao banco de dados" in result.stderr
+        assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Contexto

Resolve #49 (3.3 — CLI de registro manual de transacoes). O `TransactionRepository` (issue 3.1/#8) suportava os 6 tipos de transacao, mas so era acessivel via Python — este PR entrega a interface de CLI e fecha o gap de roadmap identificado na discussao da #9.

## O que muda

- **`bogle buy` / `bogle sell` / `bogle income`** — comandos finos sobre o `TransactionRepository`. `--date` opcional com default hoje (America/Sao_Paulo), aceitando ISO `YYYY-MM-DD` para backfill. Validacao por tipo de provento: **JCP exige `--tax-withheld`** (15% retido na fonte) e **RENDIMENTO o rejeita** (isento para PF); DIVIDEND/INTEREST opcionais. Validacao de faixas fica no repository, que ja agrega erros amigaveis.
- **`bogle transactions [ticker]`** — tabela rich com Decimais normalizados (sem a escala crua do NUMERIC) e colunas Qtd/Preco com placeholder para proventos.
- **`bogle transaction remove <id>`** — remocao por ID com erro amigavel.
- **`cli/parsing.py` (novo)** — parsers compartilhados extraidos de `assets.py`; `parse_decimal` agora rejeita `NaN`/`Infinity` (estouravam em comparacoes), endurecendo tambem `--weight`/`--rate`.
- **Erro amigavel para banco indisponivel** — `psycopg.OperationalError` capturado no shim `_run` (pre-existente desde o Epico 1, violava o "nunca stack trace"; herdado pelos 5 comandos novos).
- **README** — secao *Recording transactions* com todos os comandos e a **convencao de renda fixa sem liquidez diaria** (aplicacao = BUY `shares=1` com `--price` = valor aplicado; resgate total = SELL `shares=1`), origem na issue #9. Sequencia completa do README executada de ponta a ponta num banco limpo.

## Decisoes de design

- `IncomeType` e enum local da CLI (subconjunto de `TransactionType`) para o `--help` so oferecer os 4 proventos; `--type BUY` sai com exit 2 do typer (testado).
- `bogle transactions` (plural) lista; `bogle transaction remove <id>` e sub-app — formato da issue.
- Exemplos do README calibrados para copy-paste integral (PETR4 registrado apos o `remove VTI` para respeitar a soma de pesos <= 1.0).

## Criterios de aceite

- [x] Erros amigaveis via `BogleError` — nunca stack trace (incluindo banco indisponivel)
- [x] `--date` default = hoje (America/Sao_Paulo); aceita ISO `YYYY-MM-DD`
- [x] README atualizado com a secao de transacoes e a convencao de renda fixa
- [x] Testes de CLI fim-a-fim por comando

## Revisao

Passou por revisao multi-agente adversarial (21 agentes, 4 lentes): criterios de aceite executados contra a CLI real, casos de borda de UX, mutation testing e consistencia. 14 achados confirmados e corrigidos — destaque para o isolamento dos testes de listagem vazia (dependiam da ordem de execucao) e mutantes sobreviventes em `--tax-withheld` de DIVIDEND e `amount` dos proventos.

## Testes

Suite passa de 123 para **151**: fim-a-fim por comando com assercao de persistencia via repository, timezone do default de `--date`, regras por tipo de provento, erros sem traceback (ticker inexistente, decimal/data invalidos, faixas do repository, banco indisponivel), listagem com filtro e placeholder, remocao por ID e parsers compartilhados (NaN/Infinity). ruff e pyright limpos.
