### PR TITLE
feat(tax): milestone v0.6 — calculos de IR e IOF (Epico 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 
 *.md
 !README.md
+# Documentacao de referencia versionada (docs/tax_rules.md etc.)
+!docs/
+!docs/**

--- a/docs/tax_rules.md
+++ b/docs/tax_rules.md
@@ -146,6 +146,58 @@ entre a aplicacao e o resgate:
 
 ---
 
+## IOF — tabela regressiva (renda fixa)
+
+O IOF sobre renda fixa so importa para **resgates nos primeiros 30 dias** corridos
+apos a aplicacao. Base para `src/bogle/tax/iof.py` (issue 4.4).
+
+### Aplicacao
+
+- Incide **apenas sobre o rendimento** (nunca sobre o principal).
+- Aplica-se **somente se o resgate ocorrer ate o 30o dia corrido** desde a compra.
+- A partir do **30o dia a aliquota e zero** (e, portanto, do 31o em diante).
+- **No mesmo dia** (`dias <= 0`): zero — ainda nao ha rendimento.
+- O `dia` e contado como `(data_resgate - data_compra).days` (dias corridos), onde a
+  data de compra e a `transaction_date` do `BUY` correspondente.
+
+### Tabela (Decreto 6.306/2007, Anexo)
+
+| Dia | Aliquota | Dia | Aliquota |
+|---|---|---|---|
+| 1 | 96% | 16 | 46% |
+| 2 | 93% | 17 | 43% |
+| 3 | 90% | 18 | 40% |
+| 4 | 86% | 19 | 36% |
+| 5 | 83% | 20 | 33% |
+| 6 | 80% | 21 | 30% |
+| 7 | 76% | 22 | 26% |
+| 8 | 73% | 23 | 23% |
+| 9 | 70% | 24 | 20% |
+| 10 | 66% | 25 | 16% |
+| 11 | 63% | 26 | 13% |
+| 12 | 60% | 27 | 10% |
+| 13 | 56% | 28 | 6% |
+| 14 | 53% | 29 | **3%** |
+| 15 | 50% | 30 | **0%** |
+
+> A tabela oficial decresce ate **3% no dia 29** e **zera no dia 30**. Esta versao
+> bate, dia a dia, com o dict `IOF_RATES` da issue 4.4.
+
+- Fonte: Decreto 6.306/2007, Anexo (Tabela de aliquotas do IOF).
+
+### Ativos
+
+- **Sujeitos a IOF (primeiros 30 dias):** `CDB`, `RDB`, `LCI`, `LCA`, `TESOURO`,
+  `CAIXINHA`.
+- **Isentos de IOF:** renda variavel — `STOCK`, `BDR`, `FII`, `ETF`.
+
+### Observacao pratica
+
+A maioria das `LCI`/`LCA` tem **carencia minima > 90 dias**, o que torna o IOF
+irrelevante na pratica (o resgate nunca cai dentro dos 30 dias).
+
+---
+
 ## Apendice informativo — instrumentos fora do `AssetType`
 
 Citados nas fontes, mas **nao representaveis** no schema atual (`AssetType` nao tem o
@@ -178,3 +230,5 @@ valor correspondente). Listados so para referencia; o `bogle` nao os calcula.
   <https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2011/lei/l12431.htm>
 - **Lei 15.270/2025** — tributacao de dividendos e IRPFM a partir de 2026:
   <https://www.planalto.gov.br/ccivil_03/_ato2023-2026/2025/lei/l15270.htm>
+- **Decreto 6.306/2007** — Regulamento do IOF; tabela regressiva de renda fixa (Anexo):
+  <https://www.planalto.gov.br/ccivil_03/_ato2007-2010/2007/decreto/d6306.htm>

--- a/docs/tax_rules.md
+++ b/docs/tax_rules.md
@@ -1,0 +1,180 @@
+# Regras fiscais — IR e IOF (referencia)
+
+Documento de referencia das regras de **Imposto de Renda (IR)** e **IOF** aplicaveis a
+pessoa fisica (PF) residente no Brasil, por tipo de ativo suportado pelo `bogle`.
+Base para os modulos de calculo `src/bogle/tax/income_tax.py` (issue 4.3) e
+`src/bogle/tax/iof.py` (issue 4.4).
+
+> **Escopo e isencao de responsabilidade.** Este documento cobre apenas o que o
+> `bogle` calcula por operacao. Apuracao mensal consolidada, compensacao de
+> prejuizo, DARF, IRPFM (imposto minimo de altas rendas) e o limite mensal de
+> dividendos por pagador sao apuracao **anual/mensal agregada** e ficam no Epico 11.
+> Nao e aconselhamento fiscal; valores legais podem mudar — confira as fontes.
+
+Legislacao vigente refletida: **2026** (inclui a Lei 15.270/2025, em vigor desde
+01/01/2026).
+
+---
+
+## Mapa por `AssetType`
+
+O enum `AssetType` (`src/bogle/domain/assets.py`) tem 10 valores. A tabela abaixo
+mapeia cada um a sua regra de IR, **um a um**. Detalhes e fontes nas secoes seguintes.
+
+| `AssetType` | Classe | IR sobre ganho de capital / venda | IR sobre proventos | Isencao |
+|---|---|---|---|---|
+| `STOCK`   | Acao              | 15% sobre lucro liquido | Dividendos: ver secao (Lei 15.270/2025). JCP: 15% retido | Vendas mensais ate **R$ 20.000** (so acoes) |
+| `BDR`     | BDR               | 15% sobre lucro | Dividendos seguem regra do ativo subjacente / retido na fonte | **Sem** isencao por valor |
+| `FII`     | Fundo imobiliario | **20%** sobre lucro na venda | Rendimento mensal **isento** (PF, requisitos legais) | So o rendimento mensal; ganho de capital nao tem isencao |
+| `ETF`     | ETF (renda variavel) | 15% sobre ganho de capital | — | **Sem** isencao (ver limitacao ETF-RF) |
+| `TESOURO` | Tesouro Direto    | Tabela regressiva sobre o rendimento | — | Nenhuma (regressiva) |
+| `CDB`     | CDB               | Tabela regressiva sobre o rendimento | — | Nenhuma (regressiva) |
+| `RDB`     | RDB               | Tabela regressiva sobre o rendimento | — | Nenhuma (regressiva) |
+| `LCI`     | LCI               | **Isento** | — | **Isento** de IR para PF |
+| `LCA`     | LCA               | **Isento** | — | **Isento** de IR para PF |
+| `CAIXINHA`| Caixinha (renda fixa) | Tabela regressiva sobre o rendimento | — | Nenhuma (tratada como renda fixa) |
+
+---
+
+## Renda variavel
+
+### Acoes (`STOCK`) — swing trade
+
+- **Aliquota:** 15% sobre o lucro liquido da venda (preco de venda - custo de
+  aquisicao - taxas).
+- **Isencao mensal:** vendas de acoes no mercado a vista cujo total no mes seja
+  **igual ou inferior a R$ 20.000,00** sao isentas. O limite e por **mes** e por
+  **PF**, e aplica-se **somente a acoes** (nao a BDR, FII nem ETF). Quando o total
+  vendido no mes ultrapassa o limite, o IR incide sobre **todo** o lucro do mes
+  (nao apenas sobre o excedente).
+  - Fonte: Lei 11.033/2004, art. 3, I.
+- **Retencao na fonte ("dedo-duro"):** 0,005% sobre o valor das vendas (alienacoes)
+  superiores a R$ 1,00, retida pela corretora. Funciona como antecipacao e
+  alimenta a malha fina. No `bogle` esse valor ja vem em `Transaction.tax_withheld`
+  do `SELL`.
+  - Fonte: IN RFB 1.585/2015, art. 56.
+
+### Acoes — day trade (informativo, nao implementado)
+
+- 20% sobre o lucro, com 1% retido na fonte.
+- **Fora de escopo.** Incompativel com a filosofia Boglehead do projeto (long-only,
+  buy-and-hold). O `bogle` nao tem caminho de calculo para day trade.
+  - Fonte: IN RFB 1.585/2015, art. 57 e art. 65.
+
+### BDR (`BDR`)
+
+- 15% sobre o lucro na venda. **Sem** isencao por valor (a regra dos R$ 20.000 vale
+  so para acoes). Dividendos do ativo subjacente normalmente chegam ja liquidos de
+  imposto retido no exterior/na fonte.
+  - Fonte: IN RFB 1.585/2015.
+
+### FII (`FII`)
+
+- **Ganho de capital na venda:** 20% sobre o lucro, **sem** isencao por valor.
+  - Fonte: Lei 11.196/2005, art. 125; IN RFB 1.585/2015, art. 28.
+- **Rendimentos mensais distribuidos:** **isentos** de IR para PF, desde que (todos):
+  1. o fundo tenha cotas negociadas exclusivamente em bolsa ou mercado de balcao
+     organizado;
+  2. o fundo tenha, no minimo, **50 cotistas**;
+  3. o cotista PF nao detenha **10% ou mais** das cotas (nem receba 10%+ dos
+     rendimentos).
+  - Fonte: Lei 11.196/2005, art. 3, parag. unico, III.
+  - No `bogle`, rendimento de FII e a transacao `RENDIMENTO` (sempre isenta).
+
+### ETF de renda variavel (`ETF`)
+
+- 15% sobre o ganho de capital na venda, **sem** isencao por valor.
+  - Fonte: IN RFB 1.585/2015.
+
+> **Limitacao conhecida — ETF de renda fixa.** ETFs de renda fixa seguem **tabela
+> regressiva por prazo medio da carteira** (25% ate 180 dias / 20% / **15%** acima de
+> 720 dias) — regra distinta da do ETF de renda variavel. O enum `AssetType` **nao
+> distingue** ETF-RV de ETF-RF: o `bogle` trata todo `ETF` como renda variavel (15%).
+> Para ETF de renda fixa o valor calculado pode divergir. *Informativo.*
+> Fonte: Lei 13.043/2014, art. 2 a 5.
+
+### Dividendos de acoes (PF) — regra alterada em 2026
+
+- **Ate 2025:** dividendos pagos por empresas a PF eram **isentos** de IR
+  (Lei 9.249/1995, art. 10).
+- **Desde 01/01/2026 (Lei 15.270/2025):** ha **IRRF de 10%** quando a soma dos
+  dividendos pagos por **uma mesma empresa a uma mesma PF** exceder **R$ 50.000 em um
+  mesmo mes**. Abaixo desse limite mensal por pagador, permanece isento.
+- **Transicao:** lucros apurados ate 2025, cuja distribuicao foi aprovada ate
+  31/12/2025, continuam isentos.
+- **Efeito pratico:** para o investidor PF de longo prazo (recebendo < R$ 50 mil/mes
+  por pagador) o IR sobre dividendos continua ~zero.
+- **No `bogle`:** o limite mensal por pagador e o IRPFM (imposto minimo anual de
+  altas rendas) sao apuracao **anual/mensal agregada** -> Epico 11. A funcao por
+  operacao `income_tax_on_dividend` apenas reflete o que **ja foi retido na fonte**
+  (campo `tax_withheld` do `DIVIDEND`); nao reabre o calculo do limite.
+  - Fonte: Lei 15.270/2025; Lei 9.249/1995, art. 10 (regra de transicao).
+
+### JCP — Juros sobre Capital Proprio
+
+- **15% retido na fonte**, definitivamente (nao muda com a reforma de 2026).
+  - Fonte: Lei 9.249/1995, art. 9, parag. 2.
+  - No `bogle`, o JCP e a transacao `JCP`, com o IR retido em `tax_withheld`.
+
+---
+
+## Renda fixa — tabela regressiva de IR
+
+Incide sobre o **rendimento** (nao sobre o principal), conforme o prazo decorrido
+entre a aplicacao e o resgate:
+
+| Prazo decorrido | Aliquota |
+|---|---|
+| ate 180 dias | **22,5%** |
+| 181 a 360 dias | **20,0%** |
+| 361 a 720 dias | **17,5%** |
+| acima de 720 dias | **15,0%** |
+
+- Fonte: Lei 11.033/2004, art. 1.
+- **Aplicavel a:** `TESOURO`, `CDB`, `RDB`.
+- **`CAIXINHA`:** por padrao tratada como **renda fixa** (tabela regressiva acima).
+  Esta e a regra **deterministica** que a 4.3 implementa; variacoes por emissor
+  ficam fora de escopo.
+- O retido na fonte no resgate ja vem em `tax_withheld` da transacao de saida.
+
+---
+
+## Isentos de IR para PF
+
+- **`LCI` e `LCA`:** rendimentos **isentos** de IR para pessoa fisica.
+  - Fonte: Lei 11.033/2004, art. 3, II e IV (com redacao da Lei 12.431/2011).
+
+---
+
+## Apendice informativo — instrumentos fora do `AssetType`
+
+Citados nas fontes, mas **nao representaveis** no schema atual (`AssetType` nao tem o
+valor correspondente). Listados so para referencia; o `bogle` nao os calcula.
+
+| Instrumento | Tratamento de IR (PF) | Observacao |
+|---|---|---|
+| CRI / CRA | Isento | Lei 11.033/2004 / Lei 12.431/2011 |
+| Debentures incentivadas | Isento | Lei 12.431/2011, art. 2 |
+| Fundos de renda fixa (abertos) | Regressiva + "come-cotas" semestral | Tributacao periodica nao modelada |
+| ETF de renda fixa | Regressiva por prazo medio (25%/20%/15%) | Tratado como `ETF` RV (15%) — limitacao acima |
+| Day trade (qualquer RV) | 20% + 1% retido | Incompativel com a filosofia do projeto |
+
+---
+
+## Fontes oficiais
+
+- **IN RFB 1.585/2015** — consolida o IR no mercado financeiro e de capitais:
+  <https://normas.receita.fazenda.gov.br/sijut2consulta/link.action?idAto=67494>
+- **Lei 11.033/2004** — tabela regressiva de renda fixa (art. 1), isencao de R$ 20 mil
+  em acoes (art. 3, I), isencao de LCI/LCA (art. 3):
+  <https://www.planalto.gov.br/ccivil_03/_ato2004-2006/2004/lei/l11033.htm>
+- **Lei 11.196/2005** — FII (ganho de capital e isencao de rendimento, art. 3 e 125):
+  <https://www.planalto.gov.br/ccivil_03/_ato2004-2006/2005/lei/l11196.htm>
+- **Lei 9.249/1995** — JCP (art. 9) e isencao historica de dividendos (art. 10):
+  <https://www.planalto.gov.br/ccivil_03/leis/l9249.htm>
+- **Lei 13.043/2014** — ETF de renda fixa (art. 2 a 5):
+  <https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2014/lei/l13043.htm>
+- **Lei 12.431/2011** — debentures incentivadas e isencoes correlatas:
+  <https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2011/lei/l12431.htm>
+- **Lei 15.270/2025** — tributacao de dividendos e IRPFM a partir de 2026:
+  <https://www.planalto.gov.br/ccivil_03/_ato2023-2026/2025/lei/l15270.htm>

--- a/src/bogle/domain/cost_basis.py
+++ b/src/bogle/domain/cost_basis.py
@@ -1,0 +1,58 @@
+"""Weighted-average acquisition cost from a transaction history (issue 4.5).
+
+Pure functions over ``Transaction`` rows. The ``holdings`` view deliberately
+does not compute average cost or realized PnL, so this is the single source of
+truth reused by income-tax (4.3), current position (6.1) and reports (8.5).
+
+Brazilian "preco medio ponderado" method (accepted by the RFB for individuals):
+
+- Average cost per share = SUM(BUY total_cost) / SUM(BUY shares). Purchase fees
+  are already folded into ``total_cost`` (= total_investment + fees), so they
+  compose the cost.
+- Sales reduce the remaining quantity but **never** change the average cost of
+  the units still held.
+- Fixed income without daily liquidity uses the BUY ``shares=1`` /
+  ``unit_price=amount applied`` convention; the same formula yields
+  ``total_cost`` of the single unit, so it needs no special case.
+
+Everything is ``Decimal``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from bogle.domain.errors import ValidationError
+from bogle.domain.transactions import Transaction, TransactionType
+
+_ZERO = Decimal("0")
+
+
+def average_cost_per_share(transactions: list[Transaction]) -> Decimal:
+    """Weighted-average cost of one share, from the BUYs in ``transactions``.
+
+    Only ``BUY`` rows count; sales, dividends and other events are ignored.
+    Purchase fees are included (they are part of each BUY's ``total_cost``).
+
+    Raises ``ValidationError`` if there are no purchases (the average is
+    undefined and dividing by zero shares would be a bug, not a 0 result).
+    """
+    total_cost = _ZERO
+    total_shares = _ZERO
+    for tx in transactions:
+        if tx.transaction_type is TransactionType.BUY:
+            total_cost += tx.total_cost
+            total_shares += tx.shares
+    if total_shares <= _ZERO:
+        raise ValidationError("Sem compras registradas para calcular o custo medio.")
+    return total_cost / total_shares
+
+
+def acquisition_cost(transactions: list[Transaction], shares_sold: Decimal) -> Decimal:
+    """Acquisition cost of ``shares_sold`` units = average cost * quantity.
+
+    The cost basis to subtract from sale proceeds when computing capital gains.
+    Uses the weighted-average price, so a partial sale carries a proportional
+    slice of the total cost and leaves the remaining units' average unchanged.
+    """
+    return average_cost_per_share(transactions) * shares_sold

--- a/src/bogle/tax/__init__.py
+++ b/src/bogle/tax/__init__.py
@@ -1,0 +1,1 @@
+"""Tax calculations (IR and IOF) — see docs/tax_rules.md for the rules."""

--- a/src/bogle/tax/income_tax.py
+++ b/src/bogle/tax/income_tax.py
@@ -1,0 +1,143 @@
+"""Per-operation income tax (IR) for the asset types bogle supports (issue 4.3).
+
+Pure functions; the rules are documented in ``docs/tax_rules.md`` (issue 4.1) and
+reflect the 2026 legislation. Cost basis comes ready from
+``bogle.domain.cost_basis`` (issue 4.5) — this module does not recompute it.
+
+Out of scope (Epico 11 / informative): monthly consolidated apuration, loss
+carry-forward, DARF, the R$50k/month-per-payer dividend threshold and the IRPFM
+(both annual aggregates), and day trade. These functions compute one operation at
+a time and never aggregate across the month — the caller supplies any monthly
+total it needs (e.g. ``monthly_stock_sales_total``).
+
+All values are ``Decimal`` and are NOT rounded to centavos; rounding belongs to
+the DARF layer (Epico 11).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from bogle.domain.assets import (
+    FIXED_INCOME_TYPES,
+    Asset,
+    AssetType,
+)
+from bogle.domain.errors import ValidationError
+from bogle.domain.transactions import Transaction
+
+_ZERO = Decimal("0")
+
+# Capital-gain rate on the sale of variable-income assets.
+_SALE_RATES: dict[AssetType, Decimal] = {
+    AssetType.STOCK: Decimal("0.15"),
+    AssetType.BDR: Decimal("0.15"),
+    AssetType.ETF: Decimal("0.15"),
+    AssetType.FII: Decimal("0.20"),
+}
+
+# Monthly stock-sale value at or below which the gain is IR-exempt (stocks only).
+_STOCK_MONTHLY_EXEMPTION = Decimal("20000")
+
+# IR retained at source on JCP, fixed at 15%.
+_JCP_RATE = Decimal("0.15")
+
+# Fixed-income types whose yield is IR-exempt for individuals.
+_FIXED_INCOME_EXEMPT = frozenset({AssetType.LCI, AssetType.LCA})
+
+
+def income_tax_on_sale(
+    asset: Asset,
+    sale: Transaction,
+    cost_basis: Decimal,
+    monthly_stock_sales_total: Decimal,
+) -> Decimal:
+    """IR on the capital gain of a variable-income sale.
+
+    ``gain = sale proceeds (total_investment) - sale fees - cost_basis``. A loss
+    (or zero gain) owes nothing. Rates: 15% for STOCK/BDR/ETF, 20% for FII.
+
+    Stocks are exempt when ``monthly_stock_sales_total`` (the gross sold across
+    the whole month, aggregated by the caller) is <= R$20.000; above it the full
+    gain is taxed (the exemption is all-or-nothing, not just on the excess). The
+    R$20k exemption applies to STOCK only — never to BDR, ETF or FII.
+
+    Raises ``ValidationError`` for fixed income (use ``income_tax_on_fixed_income``).
+    """
+    rate = _SALE_RATES.get(asset.asset_type)
+    if rate is None:
+        raise ValidationError(
+            f"income_tax_on_sale aplica-se a renda variavel (STOCK, BDR, ETF, FII); "
+            f"tipo {asset.asset_type} nao suportado. Para renda fixa use income_tax_on_fixed_income."
+        )
+    gain = sale.total_investment - sale.fees - cost_basis
+    if gain <= _ZERO:
+        return _ZERO
+    if asset.asset_type is AssetType.STOCK and monthly_stock_sales_total <= _STOCK_MONTHLY_EXEMPTION:
+        return _ZERO
+    return gain * rate
+
+
+def income_tax_on_dividend(asset: Asset, amount: Decimal) -> Decimal:
+    """IR on a stock dividend, per operation.
+
+    Within bogle's scope this is always zero: until 01/01/2026 dividends were
+    exempt, and from 2026 (Lei 15.270/2025) the 10% IRRF only applies above
+    R$50.000/month from the same payer — a monthly aggregate that belongs to the
+    annual apuration (Epico 11). The tax actually retained at source is recorded
+    on the transaction's ``tax_withheld``; this function does not re-derive it.
+    """
+    return _ZERO
+
+
+def income_tax_on_jcp(asset: Asset, amount: Decimal) -> Decimal:
+    """IR on JCP (juros sobre capital proprio): 15% retained at source, definitive
+    and unchanged by the 2026 reform."""
+    return amount * _JCP_RATE
+
+
+def income_tax_on_fii_rendimento(asset: Asset, amount: Decimal) -> Decimal:
+    """IR on an FII monthly distribution: exempt for individuals meeting the legal
+    requirements (listed fund, >50 cotistas, holder below 10%). Always zero."""
+    return _ZERO
+
+
+def income_tax_on_fixed_income(
+    asset: Asset,
+    purchase_date: datetime,
+    redemption_date: datetime,
+    income: Decimal,
+) -> Decimal:
+    """IR on fixed-income yield via the regressive table on the income.
+
+    LCI/LCA are exempt (returns 0). For TESOURO/CDB/RDB/CAIXINHA the rate falls
+    with the elapsed calendar days between purchase and redemption: 22,5% up to
+    180d, 20% to 360d, 17,5% to 720d, 15% above 720d. A non-positive ``income``
+    owes nothing.
+
+    ``purchase_date`` is the BUY's ``transaction_date``. Raises ``ValidationError``
+    for variable income.
+    """
+    if asset.asset_type not in FIXED_INCOME_TYPES:
+        raise ValidationError(
+            f"income_tax_on_fixed_income aplica-se a renda fixa "
+            f"(TESOURO, CDB, RDB, LCI, LCA, CAIXINHA); tipo {asset.asset_type} nao suportado."
+        )
+    if asset.asset_type in _FIXED_INCOME_EXEMPT:
+        return _ZERO
+    if income <= _ZERO:
+        return _ZERO
+    days = (redemption_date.date() - purchase_date.date()).days
+    return income * _regressive_rate(days)
+
+
+def _regressive_rate(days: int) -> Decimal:
+    """Regressive IR rate by elapsed days (Lei 11.033/2004, art. 1)."""
+    if days <= 180:
+        return Decimal("0.225")
+    if days <= 360:
+        return Decimal("0.20")
+    if days <= 720:
+        return Decimal("0.175")
+    return Decimal("0.15")

--- a/src/bogle/tax/iof.py
+++ b/src/bogle/tax/iof.py
@@ -1,0 +1,55 @@
+"""Regressive IOF on fixed-income redemptions (issue 4.4).
+
+Pure function; the rule is documented in ``docs/tax_rules.md`` (issue 4.2). IOF
+falls on the *income* (never the principal) and only when the redemption happens
+within the first 30 calendar days of the purchase, decreasing day by day to zero
+on day 30. Variable income (STOCK, BDR, FII, ETF) is always exempt.
+
+Decimal throughout — the table is built from strings, never from float (``Decimal(0.96)``
+would carry binary imprecision).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from bogle.domain.assets import VARIABLE_INCOME_TYPES, AssetType
+
+_ZERO = Decimal("0")
+
+# IOF rate by elapsed calendar day (Decreto 6.306/2007, Anexo). Day 30 is 0%;
+# day 31 onward is out of the table (also 0%).
+IOF_RATES: dict[int, Decimal] = {
+    1: Decimal("0.96"), 2: Decimal("0.93"), 3: Decimal("0.90"), 4: Decimal("0.86"),
+    5: Decimal("0.83"), 6: Decimal("0.80"), 7: Decimal("0.76"), 8: Decimal("0.73"),
+    9: Decimal("0.70"), 10: Decimal("0.66"), 11: Decimal("0.63"), 12: Decimal("0.60"),
+    13: Decimal("0.56"), 14: Decimal("0.53"), 15: Decimal("0.50"), 16: Decimal("0.46"),
+    17: Decimal("0.43"), 18: Decimal("0.40"), 19: Decimal("0.36"), 20: Decimal("0.33"),
+    21: Decimal("0.30"), 22: Decimal("0.26"), 23: Decimal("0.23"), 24: Decimal("0.20"),
+    25: Decimal("0.16"), 26: Decimal("0.13"), 27: Decimal("0.10"), 28: Decimal("0.06"),
+    29: Decimal("0.03"), 30: Decimal("0.00"),
+}  # fmt: skip
+
+
+def iof_on_redemption(
+    purchase_date: datetime,
+    redemption_date: datetime,
+    income: Decimal,
+    asset_type: AssetType,
+) -> Decimal:
+    """Regressive IOF on the ``income`` of a redemption.
+
+    Zero for variable income. For fixed income, zero unless the redemption falls
+    within days 1..29 of the purchase (day 30 onward is already 0%), and zero on
+    the same day (``days <= 0``) since no yield has accrued yet.
+
+    ``days = (redemption_date - purchase_date)`` counted in calendar days;
+    ``purchase_date`` is the BUY's ``transaction_date`` (not ``Asset.purchase_date``).
+    """
+    if asset_type in VARIABLE_INCOME_TYPES:
+        return _ZERO
+    days = (redemption_date.date() - purchase_date.date()).days
+    if income <= _ZERO:
+        return _ZERO
+    return income * IOF_RATES.get(days, _ZERO)

--- a/tests/test_cost_basis.py
+++ b/tests/test_cost_basis.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from bogle.domain.cost_basis import acquisition_cost, average_cost_per_share
+from bogle.domain.errors import ValidationError
+from bogle.domain.transactions import Transaction, TransactionType
+
+D = datetime(2026, 1, 10, tzinfo=UTC)
+
+
+def buy(shares: str, unit_price: str, fees: str = "0") -> Transaction:
+    s, p, f = Decimal(shares), Decimal(unit_price), Decimal(fees)
+    investment = s * p
+    return Transaction(
+        id=0,
+        ticker="X",
+        transaction_type=TransactionType.BUY,
+        date=D,
+        shares=s,
+        unit_price=p,
+        total_investment=investment,
+        fees=f,
+        total_cost=investment + f,
+        tax_withheld=Decimal("0"),
+    )
+
+
+def sell(shares: str, unit_price: str, fees: str = "0") -> Transaction:
+    s, p, f = Decimal(shares), Decimal(unit_price), Decimal(fees)
+    return Transaction(
+        id=0,
+        ticker="X",
+        transaction_type=TransactionType.SELL,
+        date=D,
+        shares=s,
+        unit_price=p,
+        total_investment=s * p,
+        fees=f,
+        total_cost=f,
+        tax_withheld=Decimal("0"),
+    )
+
+
+def income(transaction_type: TransactionType, amount: str) -> Transaction:
+    return Transaction(
+        id=0,
+        ticker="X",
+        transaction_type=transaction_type,
+        date=D,
+        shares=Decimal("0"),
+        unit_price=Decimal("0"),
+        total_investment=Decimal(amount),
+        fees=Decimal("0"),
+        total_cost=Decimal("0"),
+        tax_withheld=Decimal("0"),
+    )
+
+
+class TestAverageCostPerShare:
+    def test_weighted_average_of_buys_at_different_prices(self) -> None:
+        # (100*30 + 50*36) / 150 = 4800 / 150 = 32
+        avg = average_cost_per_share([buy("100", "30"), buy("50", "36")])
+        assert avg == Decimal("32")
+
+    def test_purchase_fees_compose_the_cost(self) -> None:
+        # (3000 + 5.5) / 100 = 30.055
+        avg = average_cost_per_share([buy("100", "30", fees="5.5")])
+        assert avg == Decimal("30.055")
+
+    def test_sales_do_not_change_the_average(self) -> None:
+        history = [buy("100", "30"), buy("50", "36"), sell("40", "50", fees="2")]
+        assert average_cost_per_share(history) == Decimal("32")
+
+    def test_income_events_are_ignored(self) -> None:
+        history = [
+            buy("100", "30"),
+            income(TransactionType.DIVIDEND, "123.45"),
+            income(TransactionType.JCP, "20"),
+        ]
+        assert average_cost_per_share(history) == Decimal("30")
+
+    def test_fixed_income_single_unit_convention(self) -> None:
+        # BUY shares=1, unit_price = amount applied -> avg = total_cost of the unit.
+        avg = average_cost_per_share([buy("1", "1000", fees="0")])
+        assert avg == Decimal("1000")
+
+    def test_result_is_decimal(self) -> None:
+        avg = average_cost_per_share([buy("3", "10")])
+        assert isinstance(avg, Decimal)
+
+    def test_no_purchases_raises(self) -> None:
+        with pytest.raises(ValidationError, match="Sem compras registradas"):
+            average_cost_per_share([sell("10", "50")])
+
+    def test_empty_history_raises(self) -> None:
+        with pytest.raises(ValidationError, match="Sem compras registradas"):
+            average_cost_per_share([])
+
+
+class TestAcquisitionCost:
+    def test_partial_sale_carries_proportional_cost(self) -> None:
+        history = [buy("100", "30"), buy("50", "36")]  # avg 32
+        assert acquisition_cost(history, Decimal("40")) == Decimal("1280")  # 32 * 40
+
+    def test_full_position_cost(self) -> None:
+        history = [buy("100", "30"), buy("50", "36")]  # avg 32, 150 shares
+        assert acquisition_cost(history, Decimal("150")) == Decimal("4800")
+
+    def test_fixed_income_redemption_cost(self) -> None:
+        # Resgate de renda fixa: SELL shares=1 -> custo = total_cost do BUY.
+        assert acquisition_cost([buy("1", "1000")], Decimal("1")) == Decimal("1000")
+
+    def test_result_is_decimal(self) -> None:
+        assert isinstance(acquisition_cost([buy("3", "10")], Decimal("1")), Decimal)

--- a/tests/test_income_tax.py
+++ b/tests/test_income_tax.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from bogle.domain.assets import Asset, AssetType
+from bogle.domain.cost_basis import acquisition_cost
+from bogle.domain.errors import ValidationError
+from bogle.domain.transactions import Transaction, TransactionType
+from bogle.tax import income_tax
+from bogle.tax.income_tax import (
+    income_tax_on_dividend,
+    income_tax_on_fii_rendimento,
+    income_tax_on_fixed_income,
+    income_tax_on_jcp,
+    income_tax_on_sale,
+)
+
+D = datetime(2026, 1, 10, tzinfo=UTC)
+PURCHASE = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def asset(asset_type: AssetType) -> Asset:
+    return Asset(ticker="X", target_weight=Decimal("0.1"), asset_type=asset_type)
+
+
+def buy(shares: str, unit_price: str, fees: str = "0") -> Transaction:
+    s, p, f = Decimal(shares), Decimal(unit_price), Decimal(fees)
+    investment = s * p
+    return Transaction(
+        id=0,
+        ticker="X",
+        transaction_type=TransactionType.BUY,
+        date=D,
+        shares=s,
+        unit_price=p,
+        total_investment=investment,
+        fees=f,
+        total_cost=investment + f,
+        tax_withheld=Decimal("0"),
+    )
+
+
+def sell(shares: str, unit_price: str, fees: str = "0") -> Transaction:
+    s, p, f = Decimal(shares), Decimal(unit_price), Decimal(fees)
+    return Transaction(
+        id=0,
+        ticker="X",
+        transaction_type=TransactionType.SELL,
+        date=D,
+        shares=s,
+        unit_price=p,
+        total_investment=s * p,
+        fees=f,
+        total_cost=f,
+        tax_withheld=Decimal("0"),
+    )
+
+
+class TestSaleVariableIncome:
+    def test_stock_below_monthly_limit_is_exempt(self) -> None:
+        # Venda de R$ 19.999 em acoes -> isento, mesmo com lucro.
+        tax = income_tax_on_sale(asset(AssetType.STOCK), sell("100", "200"), Decimal("1000"), Decimal("19999"))
+        assert tax == Decimal("0")
+
+    def test_stock_at_limit_is_exempt(self) -> None:
+        tax = income_tax_on_sale(asset(AssetType.STOCK), sell("100", "200"), Decimal("1000"), Decimal("20000"))
+        assert tax == Decimal("0")
+
+    def test_stock_above_monthly_limit_taxes_full_gain(self) -> None:
+        # Venda de R$ 20.001 no mes -> tributa todo o lucro a 15%.
+        # gain = 20001 - 0 - 18001 = 2000 ; 2000 * 0.15 = 300
+        tax = income_tax_on_sale(asset(AssetType.STOCK), sell("1", "20001"), Decimal("18001"), Decimal("20001"))
+        assert tax == Decimal("300")
+
+    def test_bdr_has_no_value_exemption(self) -> None:
+        # BDR tributa mesmo com total mensal baixo (isencao e so para acoes).
+        # gain = 5000 - 4000 = 1000 ; 15%
+        tax = income_tax_on_sale(asset(AssetType.BDR), sell("100", "50"), Decimal("4000"), Decimal("1000"))
+        assert tax == Decimal("150")
+
+    def test_etf_variable_income_15_percent_no_exemption(self) -> None:
+        tax = income_tax_on_sale(asset(AssetType.ETF), sell("100", "50"), Decimal("4000"), Decimal("1000"))
+        assert tax == Decimal("150")
+
+    def test_fii_capital_gain_20_percent_no_exemption(self) -> None:
+        # gain = 5000 - 4000 = 1000 ; 20%
+        tax = income_tax_on_sale(asset(AssetType.FII), sell("100", "50"), Decimal("4000"), Decimal("0"))
+        assert tax == Decimal("200")
+
+    def test_loss_owes_nothing(self) -> None:
+        tax = income_tax_on_sale(asset(AssetType.STOCK), sell("100", "20"), Decimal("3000"), Decimal("50000"))
+        assert tax == Decimal("0")
+
+    def test_sale_fees_reduce_the_gain(self) -> None:
+        # gain = 5000 - 10 (fees) - 4000 = 990 ; 15%
+        tax = income_tax_on_sale(asset(AssetType.BDR), sell("100", "50", fees="10"), Decimal("4000"), Decimal("0"))
+        assert tax == Decimal("148.5")
+
+    def test_partial_sale_uses_weighted_average_cost(self) -> None:
+        # Integracao com a 4.5: compras 100@30 e 50@36 -> preco medio 32.
+        history = [buy("100", "30"), buy("50", "36")]
+        cost = acquisition_cost(history, Decimal("40"))  # 32 * 40 = 1280
+        assert cost == Decimal("1280")
+        s = sell("40", "50", fees="2")  # proceeds 2000, fees 2
+        # gain = 2000 - 2 - 1280 = 718 ; acoes acima do limite -> 15%
+        tax = income_tax_on_sale(asset(AssetType.STOCK), s, cost, Decimal("25000"))
+        assert tax == Decimal("107.7")
+
+    def test_fixed_income_asset_raises(self) -> None:
+        with pytest.raises(ValidationError, match="renda variavel"):
+            income_tax_on_sale(asset(AssetType.CDB), sell("1", "1000"), Decimal("900"), Decimal("0"))
+
+    def test_result_is_decimal(self) -> None:
+        tax = income_tax_on_sale(asset(AssetType.BDR), sell("100", "50"), Decimal("4000"), Decimal("0"))
+        assert isinstance(tax, Decimal)
+
+
+class TestProventos:
+    def test_dividend_is_exempt_per_operation(self) -> None:
+        assert income_tax_on_dividend(asset(AssetType.STOCK), Decimal("100000")) == Decimal("0")
+
+    def test_jcp_15_percent_retained(self) -> None:
+        assert income_tax_on_jcp(asset(AssetType.STOCK), Decimal("200")) == Decimal("30")
+
+    def test_fii_rendimento_is_exempt(self) -> None:
+        assert income_tax_on_fii_rendimento(asset(AssetType.FII), Decimal("80")) == Decimal("0")
+
+    def test_jcp_result_is_decimal(self) -> None:
+        assert isinstance(income_tax_on_jcp(asset(AssetType.STOCK), Decimal("200")), Decimal)
+
+
+class TestFixedIncome:
+    def test_lci_is_exempt(self) -> None:
+        tax = income_tax_on_fixed_income(asset(AssetType.LCI), PURCHASE, PURCHASE + timedelta(days=90), Decimal("500"))
+        assert tax == Decimal("0")
+
+    def test_lca_is_exempt(self) -> None:
+        tax = income_tax_on_fixed_income(asset(AssetType.LCA), PURCHASE, PURCHASE + timedelta(days=400), Decimal("500"))
+        assert tax == Decimal("0")
+
+    @pytest.mark.parametrize(
+        ("days", "expected"),
+        [
+            (100, "225"),  # ate 180d -> 22,5%
+            (200, "200"),  # 181-360d -> 20%
+            (400, "175"),  # 361-720d -> 17,5%
+            (800, "150"),  # > 720d -> 15%
+        ],
+    )
+    def test_cdb_regressive_brackets(self, days: int, expected: str) -> None:
+        tax = income_tax_on_fixed_income(
+            asset(AssetType.CDB), PURCHASE, PURCHASE + timedelta(days=days), Decimal("1000")
+        )
+        assert tax == Decimal(expected)
+
+    @pytest.mark.parametrize(
+        ("days", "rate"),
+        [
+            (180, "0.225"),
+            (181, "0.20"),
+            (360, "0.20"),
+            (361, "0.175"),
+            (720, "0.175"),
+            (721, "0.15"),
+        ],
+    )
+    def test_bracket_boundaries(self, days: int, rate: str) -> None:
+        tax = income_tax_on_fixed_income(
+            asset(AssetType.TESOURO), PURCHASE, PURCHASE + timedelta(days=days), Decimal("1000")
+        )
+        assert tax == Decimal("1000") * Decimal(rate)
+
+    def test_non_positive_income_owes_nothing(self) -> None:
+        tax = income_tax_on_fixed_income(asset(AssetType.CDB), PURCHASE, PURCHASE + timedelta(days=10), Decimal("0"))
+        assert tax == Decimal("0")
+
+    def test_caixinha_treated_as_fixed_income(self) -> None:
+        tax = income_tax_on_fixed_income(
+            asset(AssetType.CAIXINHA), PURCHASE, PURCHASE + timedelta(days=100), Decimal("1000")
+        )
+        assert tax == Decimal("225")
+
+    def test_variable_income_asset_raises(self) -> None:
+        with pytest.raises(ValidationError, match="renda fixa"):
+            income_tax_on_fixed_income(asset(AssetType.STOCK), PURCHASE, PURCHASE + timedelta(days=10), Decimal("10"))
+
+    def test_result_is_decimal(self) -> None:
+        tax = income_tax_on_fixed_income(
+            asset(AssetType.CDB), PURCHASE, PURCHASE + timedelta(days=100), Decimal("1000")
+        )
+        assert isinstance(tax, Decimal)
+
+
+class TestScope:
+    def test_no_day_trade_path(self) -> None:
+        # Day trade (20% / 1%) e informativo na 4.1 e nao tem caminho de calculo.
+        assert not hasattr(income_tax, "income_tax_on_day_trade")

--- a/tests/test_iof.py
+++ b/tests/test_iof.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from bogle.domain.assets import AssetType
+from bogle.tax.iof import IOF_RATES, iof_on_redemption
+
+PURCHASE = datetime(2026, 1, 1, tzinfo=UTC)
+
+# Independent copy of the official table (Decreto 6.306/2007) to cross-check the
+# module's IOF_RATES — a typo in one will not be mirrored in the other.
+EXPECTED_RATES: dict[int, str] = {
+    1: "0.96", 2: "0.93", 3: "0.90", 4: "0.86", 5: "0.83", 6: "0.80",
+    7: "0.76", 8: "0.73", 9: "0.70", 10: "0.66", 11: "0.63", 12: "0.60",
+    13: "0.56", 14: "0.53", 15: "0.50", 16: "0.46", 17: "0.43", 18: "0.40",
+    19: "0.36", 20: "0.33", 21: "0.30", 22: "0.26", 23: "0.23", 24: "0.20",
+    25: "0.16", 26: "0.13", 27: "0.10", 28: "0.06", 29: "0.03", 30: "0.00",
+}  # fmt: skip
+
+
+def redeemed_on_day(day: int, income: str = "1000", asset_type: AssetType = AssetType.CDB) -> Decimal:
+    return iof_on_redemption(PURCHASE, PURCHASE + timedelta(days=day), Decimal(income), asset_type)
+
+
+class TestRegressiveBands:
+    @pytest.mark.parametrize("day", list(range(1, 31)))
+    def test_all_thirty_bands(self, day: int) -> None:
+        expected = Decimal("1000") * Decimal(EXPECTED_RATES[day])
+        assert redeemed_on_day(day) == expected
+
+    def test_day_1_is_96_percent(self) -> None:
+        assert redeemed_on_day(1) == Decimal("960")
+
+    def test_day_29_is_3_percent(self) -> None:
+        assert redeemed_on_day(29) == Decimal("30")
+
+    def test_day_30_is_zero(self) -> None:
+        assert redeemed_on_day(30) == Decimal("0")
+
+
+class TestEdges:
+    def test_same_day_is_zero(self) -> None:
+        assert redeemed_on_day(0) == Decimal("0")
+
+    def test_redemption_before_purchase_is_zero(self) -> None:
+        assert iof_on_redemption(PURCHASE, PURCHASE - timedelta(days=5), Decimal("1000"), AssetType.CDB) == Decimal("0")
+
+    @pytest.mark.parametrize("day", [31, 45, 365])
+    def test_after_thirty_days_is_zero(self, day: int) -> None:
+        assert redeemed_on_day(day) == Decimal("0")
+
+    def test_non_positive_income_is_zero(self) -> None:
+        assert redeemed_on_day(5, income="0") == Decimal("0")
+
+
+class TestVariableIncomeExempt:
+    @pytest.mark.parametrize("asset_type", [AssetType.STOCK, AssetType.BDR, AssetType.FII, AssetType.ETF])
+    def test_variable_income_always_zero(self, asset_type: AssetType) -> None:
+        # Mesmo no dia 1, renda variavel nao tem IOF.
+        assert redeemed_on_day(1, asset_type=asset_type) == Decimal("0")
+
+
+class TestFixedIncomeSubject:
+    @pytest.mark.parametrize(
+        "asset_type",
+        [AssetType.CDB, AssetType.RDB, AssetType.LCI, AssetType.LCA, AssetType.TESOURO, AssetType.CAIXINHA],
+    )
+    def test_fixed_income_pays_within_window(self, asset_type: AssetType) -> None:
+        assert redeemed_on_day(1, asset_type=asset_type) == Decimal("960")
+
+
+class TestTableIntegrity:
+    def test_module_table_matches_official_rates(self) -> None:
+        assert {day: str(rate) for day, rate in IOF_RATES.items()} == EXPECTED_RATES
+
+    def test_rates_are_decimal(self) -> None:
+        assert all(isinstance(rate, Decimal) for rate in IOF_RATES.values())
+
+    def test_no_float_imprecision(self) -> None:
+        # Decimal("0.96") != Decimal(0.96): a tabela deve usar strings.
+        assert IOF_RATES[1] == Decimal("0.96")
+
+    def test_result_is_decimal(self) -> None:
+        assert isinstance(redeemed_on_day(5), Decimal)


### PR DESCRIPTION
## Resumo

Resolve por completo o milestone **v0.6 — Tax (IR/IOF)** (Epico 4) numa **unica branch**, executando as 5 issues **em ordem de dependencia topologica**: documenta as regras (4.1, 4.2), implementa o pre-requisito de custo de aquisicao (4.5) e so entao os modulos de calculo que dependem dele (4.3, 4.4).

Tudo e codigo **puro** (`Decimal`, sem I/O, sem banco), testavel isoladamente, e segue as convencoes do repo (`from __future__ import annotations`, type hints completos, docstrings curtas em ingles, mensagens em pt-BR sem acentos, erros de dominio herdando de `BogleError`).

| # | Issue | Tipo | Entrega |
|---|---|---|---|
| 1 | #10 — 4.1 | docs | `docs/tax_rules.md`: IR por tipo de ativo |
| 2 | #11 — 4.2 | docs | secao de IOF em `docs/tax_rules.md` |
| 3 | #52 — 4.5 | feat | `src/bogle/domain/cost_basis.py`: preco medio ponderado |
| 4 | #12 — 4.3 | feat | `src/bogle/tax/income_tax.py`: IR por operacao |
| 5 | #13 — 4.4 | feat | `src/bogle/tax/iof.py`: IOF regressivo |

`Closes #10` · `Closes #11` · `Closes #52` · `Closes #12` · `Closes #13`

---

## Ordem de execucao e por que essa ordem

As issues tem dependencias explicitas: **4.3 depende de 4.1 + 4.5**, **4.4 depende de 4.2**, e **4.5 bloqueia 4.3**. A ordem entregue respeita isso:

```
4.1 (docs IR) ─┐
               ├─▶ 4.3 (IR)   ◀── 4.5 (custo medio)
4.2 (docs IOF) ─────▶ 4.4 (IOF)
```

1. **4.1** documenta as regras de IR (fonte da verdade para 4.3).
2. **4.2** documenta o IOF (fonte da verdade para 4.4).
3. **4.5** entrega o custo de aquisicao, que a 4.3 recebe pronto.
4. **4.3** implementa o IR consumindo 4.1 (regras) e 4.5 (custo).
5. **4.4** implementa o IOF consumindo 4.2.

---

## Commits (6, separados por tipo semantico)

| Hash | Tipo | Descricao |
|---|---|---|
| `chore` | repo | versiona o diretorio `docs/` no `.gitignore` |
| `docs` | tax | regras de IR por tipo de ativo (2026) — Closes #10 |
| `docs` | tax | tabela regressiva de IOF — Closes #11 |
| `feat` | tax | custo de aquisicao por preco medio ponderado — Closes #52 |
| `feat` | tax | IR por operacao por tipo de ativo — Closes #12 |
| `feat` | tax | IOF regressivo no resgate de renda fixa — Closes #13 |

---

## Decisoes tomadas (confirmadas antes de implementar)

- **`docs/` versus `.gitignore`:** o `.gitignore` ignorava **todo `*.md` exceto `README.md`** (por isso `TODO.md`/`CURRENT_STATE_CONTEXT.md` sao locais e os commits "docs" recentes na verdade editaram docstrings de codigo). As issues 4.1/4.2 pedem `docs/tax_rules.md` versionado. **Decisao:** liberar `docs/` no `.gitignore` (`!docs/` + `!docs/**`) e versionar o documento, num commit `chore` separado.
- **Local da 4.5:** o issue nao fixa o caminho e a funcao e reutilizavel por 4.3/6.1/8.5. **Decisao:** `src/bogle/domain/cost_basis.py` (camada de dominio, funcoes puras), com `tax/` importando de `domain/` — direcao de import natural.
- **Fluxo de aprovacao dos docs:** as issues pedem "validado e aprovado pelo usuario". **Decisao:** seguir fim-a-fim na branch unica, com revisao neste PR.
- **`repositories/assets.py`:** o `ruff format --check` aponta esse arquivo **pre-existente** (fora do milestone). Deixado **intacto** para nao poluir o diff.

---

## Detalhe por entrega

### 4.1 + 4.2 — `docs/tax_rules.md` (#10, #11)

Documento de referencia unico cobrindo IR e IOF para PF residente, com **mapa 1-para-1 dos 10 valores de `AssetType`** e fontes oficiais (links Planalto/RFB) em cada regra.

**IR — renda variavel:**
- `STOCK`: 15% sobre o lucro; **isencao para vendas mensais ate R$ 20.000** (so acoes); retencao "dedo-duro" 0,005% (Lei 11.033/2004, art. 3, I; IN RFB 1.585/2015).
- `BDR`/`ETF`: 15%, **sem** isencao por valor.
- `FII`: 20% no ganho de capital; **rendimento mensal isento** para PF (fundo listado, > 50 cotistas, PF < 10%) — Lei 11.196/2005.
- **Dividendos (2026):** IRRF de **10%** apenas acima de **R$ 50 mil/mes por pagador** (Lei 15.270/2025); abaixo, isento. Limite mensal e IRPFM sao apuracao anual (Epico 11).
- **JCP:** 15% retido na fonte (Lei 9.249/1995, art. 9).

**IR — renda fixa (tabela regressiva, Lei 11.033/2004, art. 1):** 22,5% ate 180d · 20% 181–360d · 17,5% 361–720d · 15% > 720d. Aplicavel a `TESOURO`/`CDB`/`RDB`/`CAIXINHA` (tratada deterministicamente como renda fixa). `LCI`/`LCA` **isentos**.

**IOF (Decreto 6.306/2007, Anexo):** incide so sobre o **rendimento**, apenas em resgates **ate 30 dias**; tabela completa do dia 1 (96%) ao dia 29 (3%) e dia 30 (0%). Sujeitos: `CDB`/`RDB`/`LCI`/`LCA`/`TESOURO`/`CAIXINHA`. Isentos: renda variavel.

**Apendice informativo** (nao representavel no `AssetType` atual, fora de calculo): CRI/CRA, debentures incentivadas, fundos de RF (come-cotas), ETF de renda fixa e day trade.

### 4.5 — `src/bogle/domain/cost_basis.py` (#52)

Funcoes puras sobre o historico de `transactions`:

```python
def average_cost_per_share(transactions: list[Transaction]) -> Decimal
def acquisition_cost(transactions: list[Transaction], shares_sold: Decimal) -> Decimal
```

- Preco medio = `SUM(BUY total_cost) / SUM(BUY shares)`; **taxas de compra compoem o custo** (ja embutidas em `total_cost` do BUY).
- **Vendas nao alteram o preco medio** das unidades remanescentes (metodo brasileiro).
- Convencao de **renda fixa sem liquidez diaria** (`shares=1`) sai naturalmente da mesma formula.
- Sem compras registradas → `ValidationError` (evita divisao por zero silenciosa).

### 4.3 — `src/bogle/tax/income_tax.py` (#12)

```python
def income_tax_on_sale(asset, sale, cost_basis, monthly_stock_sales_total) -> Decimal
def income_tax_on_dividend(asset, amount) -> Decimal
def income_tax_on_jcp(asset, amount) -> Decimal
def income_tax_on_fii_rendimento(asset, amount) -> Decimal
def income_tax_on_fixed_income(asset, purchase_date, redemption_date, income) -> Decimal
```

- **Venda RV:** `gain = total_investment - fees - cost_basis`; prejuizo/zero → 0; 15% STOCK/BDR/ETF, 20% FII. Isencao de R$ 20k **so para STOCK** e **tudo-ou-nada** (acima do limite, tributa o lucro inteiro). `monthly_stock_sales_total` vem agregado pelo chamador. Tipo de renda fixa → `ValidationError` (use `income_tax_on_fixed_income`).
- **Dividendo:** 0 por operacao (limite mensal/IRPFM no Epico 11; o retido fica em `tax_withheld`).
- **JCP:** 15% retido.
- **FII rendimento:** isento.
- **Renda fixa:** LCI/LCA isentos; demais via tabela regressiva por dias corridos; `income <= 0` → 0. Tipo de renda variavel → `ValidationError`.

### 4.4 — `src/bogle/tax/iof.py` (#13)

```python
IOF_RATES: dict[int, Decimal]  # dia 1..30, construido de strings (sem imprecisao de float)
def iof_on_redemption(purchase_date, redemption_date, income, asset_type) -> Decimal
```

- Renda variavel → 0 sempre. `dias <= 0` (mesmo dia) → 0. `dias >= 31` → 0. `income <= 0` → 0.
- Caso contrario: `income * IOF_RATES[dias]`. `dias` por calendario, com `purchase_date` = `transaction_date` do BUY.

---

## Verificacao

- `ruff check .` → **All checks passed**.
- `ruff format --check` → arquivos novos ja formatados (unico diff e o pre-existente `repositories/assets.py`, deixado intacto).
- `pytest` → **248 passam** (75 novos).
- Smoke test fim-a-fim: `avg=32`, `acquisition_cost(40)=1280`, `IR venda (>20k)=108,00`, `IR CDB 200d=200,00`, `IOF dia 15=500,00`.

**Cobertura de testes nova (75):**

| Arquivo | Testes | Destaques |
|---|---|---|
| `tests/test_cost_basis.py` | 12 | media ponderada, taxas no custo, venda parcial nao altera media, convencao RF `shares=1`, sem-compras levanta erro |
| `tests/test_income_tax.py` | 32 | R$ 19.999 (isento) vs R$ 20.001 (tributa total), BDR/ETF/FII sem isencao, prejuizo, venda parcial com preco medio (integra a 4.5), 4 faixas da regressiva + fronteiras (180/181/360/361/720/721), LCI/LCA isentos, JCP 15%, day trade sem caminho |
| `tests/test_iof.py` | 53 | **30 faixas** validadas contra copia independente da tabela oficial, mesmo dia, pre-compra, dia 31+, renda variavel isenta, RF sujeita, integridade/tipos da tabela |

---

## Escopo (fora deste milestone, conforme as issues)

Apuracao mensal consolidada, compensacao de prejuizo, DARF, limite de **R$ 50 mil/mes por pagador** em dividendos, **IRPFM**, **day trade** (20%/1%) e **ETF de renda fixa** (o `AssetType` nao distingue ETF-RV de ETF-RF; tratado como RV 15%) — todos marcados como informativos/limitacao conhecida no `docs/tax_rules.md` e reservados ao **Epico 11**.

---

> **Aviso:** o conteudo fiscal reflete a legislacao de 2026 (inclui a Lei 15.270/2025) e cita fontes oficiais, mas nao constitui aconselhamento fiscal.
